### PR TITLE
2020-04-24 Make text field demo page not share data between two text fields

### DIFF
--- a/BlazorMdc.Demo.CommonUI/Pages/TextFieldSample/TextFieldSample.razor
+++ b/BlazorMdc.Demo.CommonUI/Pages/TextFieldSample/TextFieldSample.razor
@@ -25,8 +25,8 @@
 <p>You typed: <strong>'@(currentValueRight ?? "")'</strong></p>
 
 <p style="margin-top: 3rem;">Password</p>
-<p><MdcTextField Label="Password" @bind-Value="@currentValueRight" TextInputStyle="MdcTextInputStyle.Outlined" Type="password" /></p>
-<p>You typed: <strong>'@(currentValueRight ?? "")'</strong></p>
+<p><MdcTextField Label="Password" @bind-Value="@currentValuePassword" TextInputStyle="MdcTextInputStyle.Outlined" Type="password" /></p>
+<p>You typed: <strong>'@(currentValuePassword ?? "")'</strong></p>
 
 
 @code {
@@ -34,4 +34,5 @@
     string currentValueOutlined;
     string currentValueFullWidth;
     string currentValueRight;
+    string currentValuePassword;
 }

--- a/BlazorMdc/BlazorMdc.csproj
+++ b/BlazorMdc/BlazorMdc.csproj
@@ -5,7 +5,7 @@
     <RazorLangVersion>3.0</RazorLangVersion>
     <Configurations>Debug_CSB;Debug_SSB;Release_CSB;Release_SSB</Configurations>
     <GeneratePackageOnBuild>true</GeneratePackageOnBuild>
-    <Version>0.21.0</Version>
+    <Version>0.22.0-Preview1</Version>
     <PackageLicenseFile>LICENSE.md</PackageLicenseFile>
     <Authors />
     <Company>Dioptra</Company>


### PR DESCRIPTION
The password & right-justified text fields were sharing a common value. This was separated.