### PR TITLE
Add libman hint

### DIFF
--- a/README.md
+++ b/README.md
@@ -82,7 +82,11 @@ We are not yet hosting a demonstration, but you can fork and download this proje
 
 ## Demonstration from local build
 
-If you have cloned the repository and are building from source there is a project 'BlazorMDC.Demo.WebServer' that should be selected as the startup project.
+If you have cloned the repository and are building from source there is a project 'BlazorMDC.Demo.WebServer' that should be selected as the startup project.  To build, you need to install `libman` if you haven't already:
+
+```console
+dotnet tool install -g Microsoft.Web.LibraryManager.Cli
+```
 
 There are four implemented solution configurations:
 


### PR DESCRIPTION
I cloned and tried to run the demo from VS 2019 but got an error `libman.json : error LIB002: The "material-components-web@6.0.0" library could not be resolved by the "unpkg" provider` - need to install libman as per this change to README.