### PR TITLE
2020-06-05 Disabled toggle for Select

### DIFF
--- a/BlazorMdc.Demo.CommonUI/Pages/SelectSample/SelectSample.razor
+++ b/BlazorMdc.Demo.CommonUI/Pages/SelectSample/SelectSample.razor
@@ -10,44 +10,61 @@
 
 <div class="mdc-layout-grid mdc-layout-grid__inner">
 	<div class="mdc-layout-grid__cell">
+		<BMdc.Switch @bind-Value="@disabled" Label="Disable selects" />
+	</div>
+</div>
+
+<div class="mdc-layout-grid mdc-layout-grid__inner">
+	<div class="mdc-layout-grid__cell">
 		<h2 class="mdc-typography--headline5">Default alignment</h2>
 		<p>
 			<BMdc.Select Label="Filled"
-								 @bind-Value="@kittenBreed1"
-								 Items="stringItems"
-								 SelectInputStyle="ESelectInputStyle.Filled"
-								 ItemValidation="@EItemValidation.NoSelection" />
+						 @bind-Value="@kittenBreed1"
+   						 Items="stringItems"
+						 SelectInputStyle="ESelectInputStyle.Filled"
+			 			 ItemValidation="@EItemValidation.NoSelection"
+						 Disabled="@disabled"/>
 		</p>
 		<p style="margin-bottom: 4em;">Selected: '<strong>@(kittenBreed1 ?? "")</strong>'</p>
 
 		<p>
-			<BMdc.Select Label="Outlined"
-								 @bind-Value="@kittenBreed2"
-								 Items="stringItems"
-								 SelectInputStyle="ESelectInputStyle.Outlined"
-								 ItemValidation="@EItemValidation.NoSelection" />
+            <BMdc.Select Label="Outlined"
+                         @bind-Value="@kittenBreed2"
+                         Items="stringItems"
+                         SelectInputStyle="ESelectInputStyle.Outlined"
+                         ItemValidation="@EItemValidation.NoSelection"
+                         Disabled="@disabled" />
 		</p>
 		<p style="margin-bottom: 4em;">Selected: '<strong>@(kittenBreed2 ?? "")</strong>'</p>
 
 		<p>
-			<BMdc.Select Label="Default to First"
-								 @bind-Value="@kittenBreed3"
-								 Items="stringItems"
-								 SelectInputStyle="ESelectInputStyle.Outlined"
-								 ItemValidation="@EItemValidation.DefaultToFirst" />
+            <BMdc.Select Label="Default to First"
+                         @bind-Value="@kittenBreed3"
+                         Items="stringItems"
+                         SelectInputStyle="ESelectInputStyle.Outlined"
+                         ItemValidation="@EItemValidation.DefaultToFirst"
+                         Disabled="@disabled" />
 
-			<BMdc.Select Label="Default to First (repeated)"
-								 @bind-Value="@kittenBreed3"
-								 Items="stringItems"
-								 SelectInputStyle="ESelectInputStyle.Outlined"
-								 ItemValidation="@EItemValidation.DefaultToFirst" />
+            <BMdc.Select Label="Default to First (repeated)"
+                         @bind-Value="@kittenBreed3"
+                         Items="stringItems"
+                         SelectInputStyle="ESelectInputStyle.Outlined"
+                         ItemValidation="@EItemValidation.DefaultToFirst"
+                         Disabled="@disabled" />
 
 		</p>
 		<p style="margin-bottom: 4em;">Selected: '<strong>@(kittenBreed3 ?? "")</strong>'</p>
 
 		<p>
-			<BMdc.Select Label="Colour Enumeration" @bind-Value="@colour" Items="colourItems"></BMdc.Select>
-			<BMdc.Select Label="Colour Enumeration (repeated)" @bind-Value="@colour" Items="colourItems"></BMdc.Select>
+            <BMdc.Select Label="Colour Enumeration"
+                         @bind-Value="@colour"
+                         Items="colourItems"
+                         Disabled="@disabled" />
+
+            <BMdc.Select Label="Colour Enumeration (repeated)"
+                         @bind-Value="@colour"
+                         Items="colourItems"
+                         Disabled="@disabled" />
 		</p>
 		<p style="margin-bottom: 4em;">Selected: '<strong>@(colour.ToString())</strong>'</p>
 
@@ -55,54 +72,59 @@
 	<div class="mdc-layout-grid__cell">
 		<h2 class="mdc-typography--headline5">Right aligned</h2>
 		<p>
-			<BMdc.Select Label="Filled"
-								 @bind-Value="@kittenBreed1"
-								 Items="stringItems"
-								 SelectInputStyle="ESelectInputStyle.Filled"
-								 TextAlignStyle="ETextAlignStyle.Right"
-								 ItemValidation="@EItemValidation.NoSelection" />
+            <BMdc.Select Label="Filled"
+                         @bind-Value="@kittenBreed1"
+                         Items="stringItems"
+                         SelectInputStyle="ESelectInputStyle.Filled"
+                         TextAlignStyle="ETextAlignStyle.Right"
+                         ItemValidation="@EItemValidation.NoSelection"
+                         Disabled="@disabled" />
 		</p>
 		<p style="margin-bottom: 4em;">Selected: '<strong>@(kittenBreed1 ?? "")</strong>'</p>
 
 		<p>
-			<BMdc.Select Label="Outlined"
-								 @bind-Value="@kittenBreed2"
-								 Items="stringItems"
-								 SelectInputStyle="ESelectInputStyle.Outlined"
-								 TextAlignStyle="ETextAlignStyle.Right"
-								 ItemValidation="@EItemValidation.NoSelection" />
+            <BMdc.Select Label="Outlined"
+                         @bind-Value="@kittenBreed2"
+                         Items="stringItems"
+                         SelectInputStyle="ESelectInputStyle.Outlined"
+                         TextAlignStyle="ETextAlignStyle.Right"
+                         ItemValidation="@EItemValidation.NoSelection"
+                         Disabled="@disabled" />
 		</p>
 		<p style="margin-bottom: 4em;">Selected: '<strong>@(kittenBreed2 ?? "")</strong>'</p>
 
 		<p>
-			<BMdc.Select Label="Default to First"
-								 @bind-Value="@kittenBreed3"
-								 Items="stringItems"
-								 SelectInputStyle="ESelectInputStyle.Outlined"
-								 TextAlignStyle="ETextAlignStyle.Right"
-								 ItemValidation="@EItemValidation.DefaultToFirst" />
+            <BMdc.Select Label="Default to First"
+                         @bind-Value="@kittenBreed3"
+                         Items="stringItems"
+                         SelectInputStyle="ESelectInputStyle.Outlined"
+                         TextAlignStyle="ETextAlignStyle.Right"
+                         ItemValidation="@EItemValidation.DefaultToFirst"
+                         Disabled="@disabled" />
 
-			<BMdc.Select Label="Default to First (repeated)"
-								 @bind-Value="@kittenBreed3"
-								 Items="stringItems"
-								 SelectInputStyle="ESelectInputStyle.Outlined"
-								 TextAlignStyle="ETextAlignStyle.Right"
-								 ItemValidation="@EItemValidation.DefaultToFirst" />
+            <BMdc.Select Label="Default to First (repeated)"
+                         @bind-Value="@kittenBreed3"
+                         Items="stringItems"
+                         SelectInputStyle="ESelectInputStyle.Outlined"
+                         TextAlignStyle="ETextAlignStyle.Right"
+                         ItemValidation="@EItemValidation.DefaultToFirst"
+                         Disabled="@disabled" />
 
 		</p>
 		<p style="margin-bottom: 4em;">Selected: '<strong>@(kittenBreed3 ?? "")</strong>'</p>
 
 		<p>
-			<BMdc.Select Label="Colour Enumeration" 
-								 @bind-Value="@colour" 
-								 TextAlignStyle="ETextAlignStyle.Right"
-								 Items="colourItems">
-			</BMdc.Select>
-			<BMdc.Select Label="Colour Enumeration (repeated)" 
-								 @bind-Value="@colour" 
-								 TextAlignStyle="ETextAlignStyle.Right"
-								 Items="colourItems">
-			</BMdc.Select>
+            <BMdc.Select Label="Colour Enumeration"
+                         @bind-Value="@colour"
+                         TextAlignStyle="ETextAlignStyle.Right"
+                         Items="colourItems"
+                         Disabled="@disabled" />
+			
+            <BMdc.Select Label="Colour Enumeration (repeated)"
+                         @bind-Value="@colour"
+                         TextAlignStyle="ETextAlignStyle.Right"
+                         Items="colourItems"
+                         Disabled="@disabled" />
 		</p>
 		<p style="margin-bottom: 4em;">Selected: '<strong>@(colour.ToString())</strong>'</p>
 
@@ -111,24 +133,25 @@
 
 
 @code {
-	string kittenBreed1;
-	string kittenBreed2;
-	string kittenBreed3;
-	Colour colour;
+    bool disabled = true;
+    string kittenBreed1;
+    string kittenBreed2;
+    string kittenBreed3;
+    Colour colour;
 
-	ListElement<string>[] stringItems = new ListElement<string>[]
-	{
-				new ListElement<string> { SelectedValue = "brit-short", Label = "British Shorthair" },
-				new ListElement<string> { SelectedValue = "russ-blue", Label = "Russian Blue" },
-				new ListElement<string> { SelectedValue = "ice-invis", Label = "Icelandic Invisible" }
-		};
+    ListElement<string>[] stringItems = new ListElement<string>[]
+    {
+                new ListElement<string> { SelectedValue = "brit-short", Label = "British Shorthair" },
+                new ListElement<string> { SelectedValue = "russ-blue", Label = "Russian Blue" },
+                new ListElement<string> { SelectedValue = "ice-invis", Label = "Icelandic Invisible" }
+        };
 
-	enum Colour { Red, Orange, Yellow, Green, Blue, Indigo, Violet };
+    enum Colour { Red, Orange, Yellow, Green, Blue, Indigo, Violet };
 
-	IEnumerable<ListElement<Colour>> colourItems => from c in (Colour[])Enum.GetValues(typeof(Colour))
-																										 select new ListElement<Colour>
-																										 {
-																											 SelectedValue = c,
-																											 Label = c.ToString()
-																										 };
+    IEnumerable<ListElement<Colour>> colourItems => from c in (Colour[])Enum.GetValues(typeof(Colour))
+                                                    select new ListElement<Colour>
+                                                    {
+                                                        SelectedValue = c,
+                                                        Label = c.ToString()
+                                                    };
 }

--- a/BlazorMdc.Demo.WebServer/Pages/index_server.cshtml
+++ b/BlazorMdc.Demo.WebServer/Pages/index_server.cshtml
@@ -13,7 +13,10 @@
 
     <link href="https://use.fontawesome.com/releases/v5.13.0/css/all.css" integrity="sha384-Bfad6CLCknfcloXFOyFnlgtENryhrpZCe29RTifKEixXQZ38WheV+i/6YWSzkz3V" crossorigin="anonymous" rel="stylesheet">
     <link href="https://cdnjs.cloudflare.com/ajax/libs/open-iconic/1.1.1/font/css/open-iconic.min.css" crossorigin="anonymous" rel="stylesheet" />
-    <link href="_content/BlazorMdc/blazormdc-bundled.min.css" rel="stylesheet" />
+    @* Do not use the bundled packages here, because it limits ability to debug *@
+    <link href="https://fonts.googleapis.com/icon?family=Material+Icons" rel="stylesheet">
+    <link href="https://unpkg.com/material-components-web@6.0.0/dist/material-components-web.min.css" rel="stylesheet" />
+    <link href="_content/BlazorMdc/blazormdc.css" rel="stylesheet" />
     <link href="_content/BlazorMdc.Demo.CommonUI/css/styles.css" rel="stylesheet" />
 </head>
 <body class="mdc-typography">
@@ -32,7 +35,9 @@
         <a class="dismiss">🗙</a>
     </div>
 
-    <script src="_content/BlazorMdc/blazormdc-bundled.min.js"></script>
+    @* Do not use the bundled packages here, because it limits ability to debug *@
+    <script src="https://unpkg.com/material-components-web@6.0.0/dist/material-components-web.min.js"></script>
+    <script src="_content/BlazorMdc/blazormdc.js"></script>
     <script src="_framework/blazor.server.js"></script>
 </body>
 </html>

--- a/BlazorMdc/BMdc/Checkbox/Checkbox.razor.cs
+++ b/BlazorMdc/BMdc/Checkbox/Checkbox.razor.cs
@@ -2,7 +2,7 @@
 
 using Microsoft.AspNetCore.Components;
 using Microsoft.JSInterop;
-
+using System;
 using System.Threading.Tasks;
 
 namespace BMdc
@@ -38,14 +38,17 @@ namespace BMdc
             ClassMapper
                 .Add("mdc-checkbox mdc-checkbox--touch")
                 .AddIf("mdc-checkbox--disabled", () => Disabled);
+
+            OnValueSet += OnValueSetCallback;
         }
 
 
-        /// <inheritdoc/>
-        protected override void OnValueSet()
-        {
-            AllowNextRender = true;
-        }
+        /// <summary>
+        /// Callback for value the value setter.
+        /// </summary>
+        /// <param name="sender"></param>
+        /// <param name="e"></param>
+        protected void OnValueSetCallback(object sender, EventArgs e) => AllowNextRender = true;
 
 
         /// <inheritdoc/>

--- a/BlazorMdc/BMdc/CircularProgress/CircularProgress.razor.cs
+++ b/BlazorMdc/BMdc/CircularProgress/CircularProgress.razor.cs
@@ -4,7 +4,7 @@ using BMdcModel;
 
 using Microsoft.AspNetCore.Components;
 using Microsoft.JSInterop;
-
+using System;
 using System.Threading.Tasks;
 
 namespace BMdc
@@ -84,6 +84,8 @@ namespace BMdc
                 .AddIf("mdc-circular-progress--large", () => CircularProgressSize == ECircularProgressSize.Large)
                 .AddIf("mdc-circular-progress--indeterminate", () => CircularProgressType == ECircularProgressType.Indeterminate)
                 .AddIf("mdc-circular-progress--closed", () => CircularProgressType == ECircularProgressType.Closed);
+
+            OnValueSet += OnValueSetCallback;
         }
 
 
@@ -94,8 +96,12 @@ namespace BMdc
         }
 
 
-        /// <inheritdoc/>
-        protected override void OnValueSet() => InvokeAsync(async () => await JsRuntime.InvokeAsync<object>("BlazorMdc.circularProgress.setProgress", ElementReference, Value));
+        /// <summary>
+        /// Callback for value the value setter.
+        /// </summary>
+        /// <param name="sender"></param>
+        /// <param name="e"></param>
+        protected void OnValueSetCallback(object sender, EventArgs e) => InvokeAsync(async () => await JsRuntime.InvokeAsync<object>("BlazorMdc.circularProgress.setProgress", ElementReference, Value));
 
 
         /// <inheritdoc/>

--- a/BlazorMdc/BMdc/IconButtonToggle/IconButtonToggle.razor.cs
+++ b/BlazorMdc/BMdc/IconButtonToggle/IconButtonToggle.razor.cs
@@ -4,7 +4,7 @@ using BMdcModel;
 
 using Microsoft.AspNetCore.Components;
 using Microsoft.JSInterop;
-
+using System;
 using System.Threading.Tasks;
 
 namespace BMdc
@@ -54,6 +54,8 @@ namespace BMdc
                 .Add("mdc-icon-button")
                 .AddIf("mdc-card__action mdc-card__action--icon", () => (Card != null))
                 .AddIf("mdc-icon-button--on", () => Value);
+
+            OnValueSet += OnValueSetCallback;
         }            
 
 
@@ -66,8 +68,12 @@ namespace BMdc
         }
 
 
-        /// <inheritdoc/>
-        protected override void OnValueSet() => InvokeAsync(async () => await JsRuntime.InvokeAsync<object>("BlazorMdc.iconButtonToggle.setOn", ElementReference, Value));
+        /// <summary>
+        /// Callback for value the value setter.
+        /// </summary>
+        /// <param name="sender"></param>
+        /// <param name="e"></param>
+        protected void OnValueSetCallback(object sender, EventArgs e) => InvokeAsync(async () => await JsRuntime.InvokeAsync<object>("BlazorMdc.iconButtonToggle.setOn", ElementReference, Value));
 
 
         /// <inheritdoc/>

--- a/BlazorMdc/BMdc/LinearProgress/LinearProgress.razor.cs
+++ b/BlazorMdc/BMdc/LinearProgress/LinearProgress.razor.cs
@@ -4,7 +4,7 @@ using BMdcModel;
 
 using Microsoft.AspNetCore.Components;
 using Microsoft.JSInterop;
-
+using System;
 using System.Threading.Tasks;
 
 namespace BMdc
@@ -39,7 +39,7 @@ namespace BMdc
                 if (value != _bufferValue)
                 {
                     _bufferValue = value;
-                    OnValueSet();
+                    OnValueSetCallback(null, null);
                 }    
             }
         }
@@ -67,6 +67,8 @@ namespace BMdc
                 .AddIf("mdc-linear-progress--indeterminate", () => LinearProgressType == ELinearProgressType.Indeterminate)
                 .AddIf("mdc-linear-progress--reversed", () => LinearProgressType == ELinearProgressType.ReversedDeterminate)
                 .AddIf("mdc-linear-progress--closed", () => LinearProgressType == ELinearProgressType.Closed);
+
+            OnValueSet += OnValueSetCallback;
         }
 
 
@@ -77,8 +79,12 @@ namespace BMdc
         }
 
 
-        /// <inheritdoc/>
-        protected override void OnValueSet() => InvokeAsync(async () => await JsRuntime.InvokeAsync<object>("BlazorMdc.linearProgress.setProgress", ElementReference, Value, MyBufferValue));
+        /// <summary>
+        /// Callback for value the value setter.
+        /// </summary>
+        /// <param name="sender"></param>
+        /// <param name="e"></param>
+        protected void OnValueSetCallback(object sender, EventArgs e) => InvokeAsync(async () => await JsRuntime.InvokeAsync<object>("BlazorMdc.linearProgress.setProgress", ElementReference, Value, MyBufferValue));
 
 
         /// <inheritdoc/>

--- a/BlazorMdc/BMdc/RadioButton/RadioButton.razor.cs
+++ b/BlazorMdc/BMdc/RadioButton/RadioButton.razor.cs
@@ -60,6 +60,8 @@ namespace BMdc
 
             ClassMapper
                 .Add("mdc-form-field");
+
+            OnValueSet += OnValueSetCallback;
         }
 
 
@@ -89,11 +91,12 @@ namespace BMdc
         }
 
 
-        /// <inheritdoc/>
-        protected override void OnValueSet()
-        {
-            InvokeAsync(async () => await JsRuntime.InvokeAsync<object>("BlazorMdc.radioButton.setChecked", RadioButtonReference, Value.Equals(TargetCheckedValue)).ConfigureAwait(false));
-        }
+        /// <summary>
+        /// Callback for value the value setter.
+        /// </summary>
+        /// <param name="sender"></param>
+        /// <param name="e"></param>
+        protected void OnValueSetCallback(object sender, EventArgs e) => InvokeAsync(async () => await JsRuntime.InvokeAsync<object>("BlazorMdc.radioButton.setChecked", RadioButtonReference, Value.Equals(TargetCheckedValue)).ConfigureAwait(false));
 
 
         private async Task OnInternalItemClickAsync()

--- a/BlazorMdc/BMdc/Select/Select.razor
+++ b/BlazorMdc/BMdc/Select/Select.razor
@@ -8,6 +8,7 @@
 
     <div class="mdc-select__anchor"
          role="button"
+         aria-disabled="@Disabled"
          aria-haspopup="@ListboxReference"
          aria-labelledby="@LabelId @SelectedTextId">
 

--- a/BlazorMdc/BMdc/Select/Select.razor.cs
+++ b/BlazorMdc/BMdc/Select/Select.razor.cs
@@ -4,7 +4,7 @@ using BMdcModel;
 
 using Microsoft.AspNetCore.Components;
 using Microsoft.JSInterop;
-
+using System;
 using System.Collections.Generic;
 using System.Linq;
 using System.Threading.Tasks;
@@ -76,6 +76,9 @@ namespace BMdc
 
             SelectedText = (Value is null) ? "" : Items.Where(i => object.Equals(i.SelectedValue, Value)).FirstOrDefault().Label;
             FloatingLabelClass = string.IsNullOrWhiteSpace(SelectedText) ? "" : "mdc-floating-label--float-above";
+
+            OnValueSet += OnValueSetCallback;
+            OnDisabledSet += OnDisabledSetCallback;
         }
 
 
@@ -86,12 +89,23 @@ namespace BMdc
         }
 
 
-        /// <inheritdoc/>
-        protected override void OnValueSet() => InvokeAsync(async () => await JsRuntime.InvokeAsync<object>("BlazorMdc.select.clickItem", UlReference, ItemDict[Value].Label));
+        /// <summary>
+        /// Callback for value the value setter.
+        /// </summary>
+        /// <param name="sender"></param>
+        /// <param name="e"></param>
+        protected void OnValueSetCallback(object sender, EventArgs e) => InvokeAsync(async () => await JsRuntime.InvokeAsync<object>("BlazorMdc.select.clickItem", UlReference, ItemDict[Value].Label));
+
+
+        /// <summary>
+        /// Callback for value the Disabled value setter.
+        /// </summary>
+        /// <param name="sender"></param>
+        /// <param name="e"></param>
+        protected void OnDisabledSetCallback(object sender, EventArgs e) => InvokeAsync(async () => await JsRuntime.InvokeAsync<object>("BlazorMdc.select.setDisabled", SelectReference, Disabled));
 
 
         /// <inheritdoc/>
         private protected override async Task InitializeMdcComponent() => await JsRuntime.InvokeAsync<object>("BlazorMdc.select.init", SelectReference);
-
     }
 }

--- a/BlazorMdc/BMdcFoundation/ComponentFoundation.cs
+++ b/BlazorMdc/BMdcFoundation/ComponentFoundation.cs
@@ -62,7 +62,7 @@ namespace BMdcFoundation
         private readonly string[] ReservedAttributes = { ClassAttrName, StyleAttrName, DisabledAttributeName };
         private readonly string[] EventAttributeNames = { "onfocus", "onblur", "onfocusin", "onfocusout", "onmouseover", "onmouseout", "onmousemove", "onmousedown", "onmouseup", "onclick", "ondblclick", "onwheel", "onmousewheel", "oncontextmenu", "ondrag", "ondragend", "ondragenter", "ondragleave", "ondragover", "ondragstart", "ondrop", "onkeydown", "onkeyup", "onkeypress", "onchange", "oninput", "oninvalid", "onreset", "onselect", "onselectstart", "onselectionchange", "onsubmit", "onbeforecopy", "onbeforecut", "onbeforepaste", "oncopy", "oncut", "onpaste", "ontouchcancel", "ontouchend", "ontouchmove", "ontouchstart", "ontouchenter", "ontouchleave", "ongotpointercapture", "onlostpointercapture", "onpointercancel", "onpointerdown", "onpointerenter", "onpointerleave", "onpointermove", "onpointerout", "onpointerover", "onpointerup", "oncanplay", "oncanplaythrough", "oncuechange", "ondurationchange", "onemptied", "onpause", "onplay", "onplaying", "onratechange", "onseeked", "onseeking", "onstalled", "onstop", "onsuspend", "ontimeupdate", "onvolumechange", "onwaiting", "onloadstart", "ontimeout", "onabort", "onload", "onloadend", "onprogress", "onerror", "onactivate", "onbeforeactivate", "onbeforedeactivate", "ondeactivate", "onended", "onfullscreenchange", "onfullscreenerror", "onloadeddata", "onloadedmetadata", "onpointerlockchange", "onpointerlockerror", "onreadystatechange", "onscroll" };
         private readonly string[] AriaAttributeNames = { "aria-activedescendant", "aria-atomic", "aria-autocomplete", "aria-busy", "aria-checked", "aria-controls", "aria-describedat", "aria-describedby", "aria-disabled", "aria-dropeffect", "aria-expanded", "aria-flowto", "aria-grabbed", "aria-haspopup", "aria-hidden", "aria-invalid", "aria-label", "aria-labelledby", "aria-level", "aria-live", "aria-multiline", "aria-multiselectable", "aria-orientation", "aria-owns", "aria-posinset", "aria-pressed", "aria-readonly", "aria-relevant", "aria-required", "aria-selected", "aria-setsize", "aria-sort", "aria-valuemax", "aria-valuemin", "aria-valuenow", "aria-valuetext" };
-
+        private bool disabled = false;
 
         [Inject] private protected IJSRuntime JsRuntime { get; set; }
 
@@ -93,7 +93,25 @@ namespace BMdcFoundation
         /// <summary>
         /// Gets whether the component is disabled.
         /// </summary>
-        [Parameter] public bool Disabled { get; set; } = false;
+        [Parameter] public bool Disabled
+        { 
+            get => disabled;
+            set
+            {
+                if (disabled != value)
+                {
+                    disabled = value;
+                    OnDisabledSet?.Invoke(this, null);
+                }
+            }
+        }
+
+
+        /// <summary>
+        /// Derived components can use this to get a callback from the <see cref="Disabled"/> setter when the consumer changes the value.
+        /// This allows a component to take action with Material Theme js to update the DOM to reflect the data change visually. 
+        /// </summary>
+        protected event EventHandler OnDisabledSet;
 
 
         /// <summary>
@@ -130,7 +148,7 @@ namespace BMdcFoundation
             var htmlAttributes = new Dictionary<string, object>(ComponentPureHtmlAttributes);
             var eventAttributes = new Dictionary<string, object>();
             var requiredAttributes = new Dictionary<string, object>();
-            
+
             if (splatType != SplatType.ClassAndStyleOnly)
             {
                 if (UnmatchedAttributes != null)

--- a/BlazorMdc/BMdcFoundation/InputComponentFoundation.cs
+++ b/BlazorMdc/BMdcFoundation/InputComponentFoundation.cs
@@ -51,19 +51,19 @@ namespace BMdcFoundation
                 {
                     _underlyingValue = value;
                    
-                    if (_hasInstantiated) OnValueSet();
+                    if (_hasInstantiated) OnValueSet?.Invoke(this, null);
                 }
             }
         }
 
 
         /// <summary>
-        /// Derived components can use this to get a callback the <see cref="Value"/> setter when the consumer changes the value.
+        /// Derived components can use this to get a callback from the <see cref="Value"/> setter when the consumer changes the value.
         /// This allows a component to take action with Material Theme js to update the DOM to reflect the data change visually. An
         /// example is a select where the relevant list item needs to be automatically clicked to get Material Theme to update
         /// the value shown in the <c>&lt;input&gt;</c> HTML tag.
         /// </summary>
-        protected virtual void OnValueSet() => _ = 0;
+        protected event EventHandler OnValueSet;
 
 
         /// <summary>

--- a/BlazorMdc/BMdcPlus/DatePicker/DatePicker.razor.cs
+++ b/BlazorMdc/BMdcPlus/DatePicker/DatePicker.razor.cs
@@ -74,11 +74,17 @@ namespace BMdcPlus
                 .Add("mdc-select")
                 .AddIf("mdc-select--outlined", () => AppliedInputStyle == ESelectInputStyle.Outlined)
                 .AddIf("mdc-select--disabled", () => Disabled);
+
+            OnValueSet += OnValueSetCallback;
         }
 
 
-        /// <inheritdoc/>
-        protected override void OnValueSet()
+        /// <summary>
+        /// Callback for value the value setter.
+        /// </summary>
+        /// <param name="sender"></param>
+        /// <param name="e"></param>
+        protected void OnValueSetCallback(object sender, EventArgs e)
         {
             Panel.SetParameters(true, Value);
             InvokeAsync(async () => await JsRuntime.InvokeAsync<object>("BlazorMdc.datePicker.listItemClick", Panel.ListItemReference, Utilities.DateToString(Value, DateFormat)).ConfigureAwait(false));

--- a/BlazorMdc/Scripts/scripts.js
+++ b/BlazorMdc/Scripts/scripts.js
@@ -223,7 +223,7 @@ window.BlazorMdc = {
 
     select: {
         init: function (elem) {
-            mdc.select.MDCSelect.attachTo(elem);
+            elem._select = mdc.select.MDCSelect.attachTo(elem);
         },
 
         clickItem: function (ulElem, value) {
@@ -232,6 +232,10 @@ window.BlazorMdc = {
                     ulElem.children[i].click();
                 }
             }
+        },
+
+        setDisabled: function (elem, value) {
+            elem._select.disabled = value;
         }
     },
 


### PR DESCRIPTION
Selects were unable to toggle their disabled state due to `ShouldRender()` disabling rendering. Added a callback mechanism to ComponentBase.cs and so far implemented by Select.razor.cs. The callback invokes a javascript function that sets a Material Theme disabled flag.

Also reverted the Blazor Server project to using long form BlazorMdc css and js to allow for script debugging.