### PR TITLE
Refactorings around js interop

### DIFF
--- a/BlazorMdc/Components/Autocomplete/MTAutocomplete.razor.cs
+++ b/BlazorMdc/Components/Autocomplete/MTAutocomplete.razor.cs
@@ -330,6 +330,6 @@ namespace BlazorMdc
 
 
         /// <inheritdoc/>
-        private protected override async Task InitializeMdcComponent() => await JsRuntime.InvokeAsync<object>("BlazorMdc.autoComplete.init", TextField.ElementReference, MenuReference, ObjectReference);
+        private protected override async Task InitializeMdcComponent() => await JsRuntime.InvokeVoidAsync("BlazorMdc.autoComplete.init", TextField.ElementReference, MenuReference, ObjectReference);
     }
 }

--- a/BlazorMdc/Components/Button/MTButton.razor.cs
+++ b/BlazorMdc/Components/Button/MTButton.razor.cs
@@ -89,6 +89,6 @@ namespace BlazorMdc
 
 
         /// <inheritdoc/>
-        private protected override async Task InitializeMdcComponent() => await JsRuntime.InvokeAsync<object>("BlazorMdc.button.init", ElementReference);
+        private protected override async Task InitializeMdcComponent() => await JsRuntime.InvokeVoidAsync("BlazorMdc.button.init", ElementReference);
     }
 }

--- a/BlazorMdc/Components/Card/MTCard.razor.cs
+++ b/BlazorMdc/Components/Card/MTCard.razor.cs
@@ -74,7 +74,7 @@ namespace BlazorMdc
         {
             if (firstRender && PrimaryAction != null)
             {
-                await JsRuntime.InvokeAsync<object>("BlazorMdc.cardPrimaryAction.init", PrimaryActionReference);
+                await JsRuntime.InvokeVoidAsync("BlazorMdc.cardPrimaryAction.init", PrimaryActionReference);
             }
         }
     }

--- a/BlazorMdc/Components/Checkbox/MTCheckbox.razor.cs
+++ b/BlazorMdc/Components/Checkbox/MTCheckbox.razor.cs
@@ -38,7 +38,7 @@ namespace BlazorMdc
                 if (value != _isIndetermimate)
                 {
                     _isIndetermimate = value;
-                    InvokeAsync(async () => await JsRuntime.InvokeAsync<object>("BlazorMdc.checkBox.setIndeterminate", ElementReference, _isIndetermimate));
+                    InvokeAsync(() => JsRuntime.InvokeVoidAsync("BlazorMdc.checkBox.setIndeterminate", ElementReference, _isIndetermimate));
                 }
             }
         }
@@ -94,7 +94,7 @@ namespace BlazorMdc
         /// </summary>
         /// <param name="sender"></param>
         /// <param name="e"></param>
-        protected void OnValueSetCallback(object sender, EventArgs e) => InvokeAsync(async () => await JsRuntime.InvokeAsync<object>("BlazorMdc.checkBox.setChecked", ElementReference, Value));
+        protected void OnValueSetCallback(object sender, EventArgs e) => InvokeAsync(() => JsRuntime.InvokeVoidAsync("BlazorMdc.checkBox.setChecked", ElementReference, Value));
 
 
         /// <summary>
@@ -102,10 +102,10 @@ namespace BlazorMdc
         /// </summary>
         /// <param name="sender"></param>
         /// <param name="e"></param>
-        protected void OnDisabledSetCallback(object sender, EventArgs e) => InvokeAsync(async () => await JsRuntime.InvokeAsync<object>("BlazorMdc.checkBox.setDisabled", ElementReference, AppliedDisabled));
+        protected void OnDisabledSetCallback(object sender, EventArgs e) => InvokeAsync(() => JsRuntime.InvokeVoidAsync("BlazorMdc.checkBox.setDisabled", ElementReference, AppliedDisabled));
 
 
         /// <inheritdoc/>
-        private protected override async Task InitializeMdcComponent() => await JsRuntime.InvokeAsync<object>("BlazorMdc.checkBox.init", ElementReference, FormReference, ReportingValue, IsIndeterminate, IsFormField);
+        private protected override async Task InitializeMdcComponent() => await JsRuntime.InvokeVoidAsync("BlazorMdc.checkBox.init", ElementReference, FormReference, ReportingValue, IsIndeterminate, IsFormField);
     }
 }

--- a/BlazorMdc/Components/CircularProgress/MTCircularProgress.razor.cs
+++ b/BlazorMdc/Components/CircularProgress/MTCircularProgress.razor.cs
@@ -100,10 +100,10 @@ namespace BlazorMdc
         /// </summary>
         /// <param name="sender"></param>
         /// <param name="e"></param>
-        protected void OnValueSetCallback(object sender, EventArgs e) => InvokeAsync(async () => await JsRuntime.InvokeAsync<object>("BlazorMdc.circularProgress.setProgress", ElementReference, Value));
+        protected void OnValueSetCallback(object sender, EventArgs e) => InvokeAsync(() => JsRuntime.InvokeVoidAsync("BlazorMdc.circularProgress.setProgress", ElementReference, Value));
 
 
         /// <inheritdoc/>
-        private protected override async Task InitializeMdcComponent() => await JsRuntime.InvokeAsync<object>("BlazorMdc.circularProgress.init", ElementReference, Value);
+        private protected override async Task InitializeMdcComponent() => await JsRuntime.InvokeVoidAsync("BlazorMdc.circularProgress.init", ElementReference, Value);
     }
 }

--- a/BlazorMdc/Components/DataTable/MTDataTable.razor.cs
+++ b/BlazorMdc/Components/DataTable/MTDataTable.razor.cs
@@ -54,6 +54,6 @@ namespace BlazorMdc
 
 
         /// <inheritdoc/>
-        private protected async override Task InitializeMdcComponent() => await JsRuntime.InvokeAsync<object>("BlazorMdc.dataTable.init", ElementReference);
+        private protected async override Task InitializeMdcComponent() => await JsRuntime.InvokeVoidAsync("BlazorMdc.dataTable.init", ElementReference);
     }
 }

--- a/BlazorMdc/Components/DatePicker/InternalDatePickerPanel.razor.cs
+++ b/BlazorMdc/Components/DatePicker/InternalDatePickerPanel.razor.cs
@@ -170,7 +170,7 @@ namespace BlazorMdc.Internal
             CachedReportingValue = Value;
             MonthsOffset = 0;
             SetParameters(true);
-            await JsRuntime.InvokeAsync<object>("BlazorMdc.datePicker.listItemClick", ListItemReference, CachedReportingValueText);
+            await JsRuntime.InvokeVoidAsync("BlazorMdc.datePicker.listItemClick", ListItemReference, CachedReportingValueText);
         }
 
 
@@ -210,7 +210,7 @@ namespace BlazorMdc.Internal
             {
                 ScrollToYear = false;
 
-                await JsRuntime.InvokeAsync<object>("BlazorMdc.datePicker.scrollToYear", currentYearId);
+                await JsRuntime.InvokeVoidAsync("BlazorMdc.datePicker.scrollToYear", currentYearId);
             }
         }
     }

--- a/BlazorMdc/Components/DatePicker/MTDatePicker.razor.cs
+++ b/BlazorMdc/Components/DatePicker/MTDatePicker.razor.cs
@@ -116,11 +116,11 @@ namespace BlazorMdc
         protected void OnValueSetCallback(object sender, EventArgs e)
         {
             Panel.SetParameters(true, Value);
-            InvokeAsync(async () => await JsRuntime.InvokeAsync<object>("BlazorMdc.datePicker.listItemClick", Panel.ListItemReference, Utilities.DateToString(Value, DateFormat)).ConfigureAwait(false));
+            InvokeAsync(() => JsRuntime.InvokeVoidAsync("BlazorMdc.datePicker.listItemClick", Panel.ListItemReference, Utilities.DateToString(Value, DateFormat)).ConfigureAwait(false));
         }
 
 
         /// <inheritdoc/>
-        private protected override async Task InitializeMdcComponent() => await JsRuntime.InvokeAsync<object>("BlazorMdc.datePicker.init", ElementReference);
+        private protected override async Task InitializeMdcComponent() => await JsRuntime.InvokeVoidAsync("BlazorMdc.datePicker.init", ElementReference);
     }
 }

--- a/BlazorMdc/Components/Drawer/MTDrawer.razor.cs
+++ b/BlazorMdc/Components/Drawer/MTDrawer.razor.cs
@@ -70,7 +70,7 @@ namespace BlazorMdc
         public void Toggle(bool open)
         {
             isOpen = open;
-            InvokeAsync(async () => await InitializeMdcComponent());
+            InvokeAsync(() => InitializeMdcComponent());
         }
 
 
@@ -88,6 +88,6 @@ namespace BlazorMdc
 
 
         /// <inheritdoc/>
-        private protected override async Task InitializeMdcComponent() => await JsRuntime.InvokeAsync<object>("BlazorMdc.drawer.toggle", DrawerElem, isOpen);
+        private protected override async Task InitializeMdcComponent() => await JsRuntime.InvokeVoidAsync("BlazorMdc.drawer.toggle", DrawerElem, isOpen);
     }
 }

--- a/BlazorMdc/Components/IconButton/MTIconButton.razor.cs
+++ b/BlazorMdc/Components/IconButton/MTIconButton.razor.cs
@@ -59,6 +59,6 @@ namespace BlazorMdc
 
 
         /// <inheritdoc/>
-        private protected override async Task InitializeMdcComponent() => await JsRuntime.InvokeAsync<object>("BlazorMdc.iconButton.init", ElementReference);
+        private protected override async Task InitializeMdcComponent() => await JsRuntime.InvokeVoidAsync("BlazorMdc.iconButton.init", ElementReference);
     }
 }

--- a/BlazorMdc/Components/IconButtonToggle/MTIconButtonToggle.razor.cs
+++ b/BlazorMdc/Components/IconButtonToggle/MTIconButtonToggle.razor.cs
@@ -83,7 +83,7 @@ namespace BlazorMdc
         /// </summary>
         /// <param name="sender"></param>
         /// <param name="e"></param>
-        protected void OnValueSetCallback(object sender, EventArgs e) => InvokeAsync(async () => await JsRuntime.InvokeAsync<object>("BlazorMdc.iconButtonToggle.setOn", ElementReference, Value));
+        protected void OnValueSetCallback(object sender, EventArgs e) => InvokeAsync(() => JsRuntime.InvokeVoidAsync("BlazorMdc.iconButtonToggle.setOn", ElementReference, Value));
 
 
         /// <summary>
@@ -95,6 +95,6 @@ namespace BlazorMdc
 
 
         /// <inheritdoc/>
-        private protected override async Task InitializeMdcComponent() => await JsRuntime.InvokeAsync<object>("BlazorMdc.iconButtonToggle.init", ElementReference);
+        private protected override async Task InitializeMdcComponent() => await JsRuntime.InvokeVoidAsync("BlazorMdc.iconButtonToggle.init", ElementReference);
     }
 }

--- a/BlazorMdc/Components/LinearProgress/MTLinearProgress.razor.cs
+++ b/BlazorMdc/Components/LinearProgress/MTLinearProgress.razor.cs
@@ -83,10 +83,10 @@ namespace BlazorMdc
         /// </summary>
         /// <param name="sender"></param>
         /// <param name="e"></param>
-        protected void OnValueSetCallback(object sender, EventArgs e) => InvokeAsync(async () => await JsRuntime.InvokeAsync<object>("BlazorMdc.linearProgress.setProgress", ElementReference, Value, MyBufferValue));
+        protected void OnValueSetCallback(object sender, EventArgs e) => InvokeAsync(() => JsRuntime.InvokeVoidAsync("BlazorMdc.linearProgress.setProgress", ElementReference, Value, MyBufferValue));
 
 
         /// <inheritdoc/>
-        private protected override async Task InitializeMdcComponent() => await JsRuntime.InvokeAsync<object>("BlazorMdc.linearProgress.init", ElementReference, Value, MyBufferValue);
+        private protected override async Task InitializeMdcComponent() => await JsRuntime.InvokeVoidAsync("BlazorMdc.linearProgress.init", ElementReference, Value, MyBufferValue);
     }
 }

--- a/BlazorMdc/Components/List/MTList.razor.cs
+++ b/BlazorMdc/Components/List/MTList.razor.cs
@@ -214,10 +214,10 @@ namespace BlazorMdc
         /// </summary>
         /// <param name="sender"></param>
         /// <param name="e"></param>
-        protected void OnDisabledSetCallback(object sender, EventArgs e) => InvokeAsync(async () => await JsRuntime.InvokeAsync<object>("BlazorMdc.list.init", ElementReference, (KeyboardInteractions && !AppliedDisabled), Ripple));
+        protected void OnDisabledSetCallback(object sender, EventArgs e) => InvokeAsync(() => JsRuntime.InvokeVoidAsync("BlazorMdc.list.init", ElementReference, (KeyboardInteractions && !AppliedDisabled), Ripple));
 
 
         /// <inheritdoc/>
-        private protected override async Task InitializeMdcComponent() => await JsRuntime.InvokeAsync<object>("BlazorMdc.list.init", ElementReference, (KeyboardInteractions && !AppliedDisabled), Ripple);
+        private protected override async Task InitializeMdcComponent() => await JsRuntime.InvokeVoidAsync("BlazorMdc.list.init", ElementReference, (KeyboardInteractions && !AppliedDisabled), Ripple);
     }
 }

--- a/BlazorMdc/Components/RadioButton/MTRadioButton.razor.cs
+++ b/BlazorMdc/Components/RadioButton/MTRadioButton.razor.cs
@@ -109,7 +109,7 @@ namespace BlazorMdc
         /// </summary>
         /// <param name="sender"></param>
         /// <param name="e"></param>
-        protected void OnValueSetCallback(object sender, EventArgs e) => InvokeAsync(async () => await JsRuntime.InvokeAsync<object>("BlazorMdc.radioButton.setChecked", RadioButtonReference, Value.Equals(TargetCheckedValue)).ConfigureAwait(false));
+        protected void OnValueSetCallback(object sender, EventArgs e) => InvokeAsync(() => JsRuntime.InvokeVoidAsync("BlazorMdc.radioButton.setChecked", RadioButtonReference, Value.Equals(TargetCheckedValue)).ConfigureAwait(false));
 
 
         private async Task OnInternalItemClickAsync()
@@ -119,6 +119,6 @@ namespace BlazorMdc
         }
 
 
-        private protected override async Task InitializeMdcComponent() => await JsRuntime.InvokeAsync<object>("BlazorMdc.radioButton.init", RadioButtonReference, FormReference, Value.Equals(TargetCheckedValue)).ConfigureAwait(false);
+        private protected override async Task InitializeMdcComponent() => await JsRuntime.InvokeVoidAsync("BlazorMdc.radioButton.init", RadioButtonReference, FormReference, Value.Equals(TargetCheckedValue)).ConfigureAwait(false);
     }
 }

--- a/BlazorMdc/Components/Select/MTSelect.razor.cs
+++ b/BlazorMdc/Components/Select/MTSelect.razor.cs
@@ -179,7 +179,7 @@ namespace BlazorMdc
         /// </summary>
         /// <param name="sender"></param>
         /// <param name="e"></param>
-        protected void OnValueSetCallback(object sender, EventArgs e) => InvokeAsync(async () => await JsRuntime.InvokeAsync<object>("BlazorMdc.select.setIndex", SelectReference, ItemDict.Keys.ToList().IndexOf(Value)));
+        protected void OnValueSetCallback(object sender, EventArgs e) => InvokeAsync(() => JsRuntime.InvokeVoidAsync("BlazorMdc.select.setIndex", SelectReference, ItemDict.Keys.ToList().IndexOf(Value)));
 
 
         /// <summary>
@@ -187,10 +187,10 @@ namespace BlazorMdc
         /// </summary>
         /// <param name="sender"></param>
         /// <param name="e"></param>
-        protected void OnDisabledSetCallback(object sender, EventArgs e) => InvokeAsync(async () => await JsRuntime.InvokeAsync<object>("BlazorMdc.select.setDisabled", SelectReference, AppliedDisabled));
+        protected void OnDisabledSetCallback(object sender, EventArgs e) => InvokeAsync(() => JsRuntime.InvokeVoidAsync("BlazorMdc.select.setDisabled", SelectReference, AppliedDisabled));
 
 
         /// <inheritdoc/>
-        private protected override async Task InitializeMdcComponent() => await JsRuntime.InvokeAsync<object>("BlazorMdc.select.init", SelectReference, ObjectReference);
+        private protected override async Task InitializeMdcComponent() => await JsRuntime.InvokeVoidAsync("BlazorMdc.select.init", SelectReference, ObjectReference);
     }
 }

--- a/BlazorMdc/Components/Switch/MTSwitch.razor.cs
+++ b/BlazorMdc/Components/Switch/MTSwitch.razor.cs
@@ -50,7 +50,7 @@ namespace BlazorMdc
         /// </summary>
         /// <param name="sender"></param>
         /// <param name="e"></param>
-        protected void OnValueSetCallback(object sender, EventArgs e) => InvokeAsync(async () => await JsRuntime.InvokeAsync<object>("BlazorMdc.switch.setChecked", ElementReference, Value));
+        protected void OnValueSetCallback(object sender, EventArgs e) => InvokeAsync(() => JsRuntime.InvokeVoidAsync("BlazorMdc.switch.setChecked", ElementReference, Value));
 
 
         /// <summary>
@@ -58,10 +58,10 @@ namespace BlazorMdc
         /// </summary>
         /// <param name="sender"></param>
         /// <param name="e"></param>
-        protected void OnDisabledSetCallback(object sender, EventArgs e) => InvokeAsync(async () => await JsRuntime.InvokeAsync<object>("BlazorMdc.switch.setDisabled", ElementReference, AppliedDisabled));
+        protected void OnDisabledSetCallback(object sender, EventArgs e) => InvokeAsync(() => JsRuntime.InvokeVoidAsync("BlazorMdc.switch.setDisabled", ElementReference, AppliedDisabled));
 
 
         /// <inheritdoc/>
-        private protected override async Task InitializeMdcComponent() => await JsRuntime.InvokeAsync<object>("BlazorMdc.switch.init", ElementReference, ReportingValue);
+        private protected override async Task InitializeMdcComponent() => await JsRuntime.InvokeVoidAsync("BlazorMdc.switch.init", ElementReference, ReportingValue);
     }
 }

--- a/BlazorMdc/Components/TabBar/MTTabBar.razor.cs
+++ b/BlazorMdc/Components/TabBar/MTTabBar.razor.cs
@@ -115,9 +115,9 @@ namespace BlazorMdc
         /// </summary>
         /// <param name="sender"></param>
         /// <param name="e"></param>
-        protected void OnValueSetCallback(object sender, EventArgs e) => InvokeAsync(async () => await JsRuntime.InvokeAsync<object>("BlazorMdc.tabBar.activateTab", ElementReference, Value).ConfigureAwait(false));
+        protected void OnValueSetCallback(object sender, EventArgs e) => InvokeAsync(() => JsRuntime.InvokeVoidAsync("BlazorMdc.tabBar.activateTab", ElementReference, Value).ConfigureAwait(false));
 
 
-        private protected override async Task InitializeMdcComponent() => await JsRuntime.InvokeAsync<object>("BlazorMdc.tabBar.init", ElementReference, ObjectReference).ConfigureAwait(false);
+        private protected override async Task InitializeMdcComponent() => await JsRuntime.InvokeVoidAsync("BlazorMdc.tabBar.init", ElementReference, ObjectReference).ConfigureAwait(false);
     }
 }

--- a/BlazorMdc/Components/TextArea/MTTextArea.razor.cs
+++ b/BlazorMdc/Components/TextArea/MTTextArea.razor.cs
@@ -109,7 +109,7 @@ namespace BlazorMdc
         /// </summary>
         /// <param name="sender"></param>
         /// <param name="e"></param>
-        protected void OnValueSetCallback(object sender, EventArgs e) => InvokeAsync(async () => await JsRuntime.InvokeAsync<object>("BlazorMdc.textField.setValue", ElementReference, Value));
+        protected void OnValueSetCallback(object sender, EventArgs e) => InvokeAsync(() => JsRuntime.InvokeVoidAsync("BlazorMdc.textField.setValue", ElementReference, Value));
 
 
         /// <summary>
@@ -117,7 +117,7 @@ namespace BlazorMdc
         /// </summary>
         /// <param name="sender"></param>
         /// <param name="e"></param>
-        protected void OnDisabledSetCallback(object sender, EventArgs e) => InvokeAsync(async () => await JsRuntime.InvokeAsync<object>("BlazorMdc.textField.setDisabled", ElementReference, AppliedDisabled));
+        protected void OnDisabledSetCallback(object sender, EventArgs e) => InvokeAsync(() => JsRuntime.InvokeVoidAsync("BlazorMdc.textField.setDisabled", ElementReference, AppliedDisabled));
 
 
         /// <inheritdoc/>
@@ -127,6 +127,6 @@ namespace BlazorMdc
 
 
         /// <inheritdoc/>
-        private protected override async Task InitializeMdcComponent() => await JsRuntime.InvokeAsync<object>("BlazorMdc.textField.init", ElementReference);
+        private protected override async Task InitializeMdcComponent() => await JsRuntime.InvokeVoidAsync("BlazorMdc.textField.init", ElementReference);
     }
 }

--- a/BlazorMdc/Components/TextField/MTTextField.razor.cs
+++ b/BlazorMdc/Components/TextField/MTTextField.razor.cs
@@ -142,7 +142,7 @@ namespace BlazorMdc
         /// </summary>
         /// <param name="sender"></param>
         /// <param name="e"></param>
-        protected void OnValueSetCallback(object sender, EventArgs e) => InvokeAsync(async () => await JsRuntime.InvokeAsync<object>("BlazorMdc.textField.setValue", ElementReference, Value));
+        protected void OnValueSetCallback(object sender, EventArgs e) => InvokeAsync(() => JsRuntime.InvokeVoidAsync("BlazorMdc.textField.setValue", ElementReference, Value));
 
 
         /// <summary>
@@ -150,17 +150,17 @@ namespace BlazorMdc
         /// </summary>
         /// <param name="sender"></param>
         /// <param name="e"></param>
-        protected void OnDisabledSetCallback(object sender, EventArgs e) => InvokeAsync(async () => await JsRuntime.InvokeAsync<object>("BlazorMdc.textField.setDisabled", ElementReference, AppliedDisabled));
+        protected void OnDisabledSetCallback(object sender, EventArgs e) => InvokeAsync(() => JsRuntime.InvokeVoidAsync("BlazorMdc.textField.setDisabled", ElementReference, AppliedDisabled));
 
 
         /// <inheritdoc/>
-        private protected override async Task InitializeMdcComponent() => await JsRuntime.InvokeAsync<object>("BlazorMdc.textField.init", ElementReference);
+        private protected override async Task InitializeMdcComponent() => await JsRuntime.InvokeVoidAsync("BlazorMdc.textField.init", ElementReference);
 
 
         /// <summary>
         /// Selects the text field - used by <see cref="MTNumericDoubleField"/>.
         /// </summary>
         /// <returns></returns>
-        internal async Task Select() => await JsRuntime.InvokeAsync<object>("BlazorMdc.textField.select", InputReference);
+        internal async Task Select() => await JsRuntime.InvokeVoidAsync("BlazorMdc.textField.select", InputReference);
     }
 }

--- a/BlazorMdc/Components/Tooltip/InternalTooltipAnchor.razor.cs
+++ b/BlazorMdc/Components/Tooltip/InternalTooltipAnchor.razor.cs
@@ -138,7 +138,7 @@ namespace BlazorMdc.Internal
                         orderby t.TimeStamp
                         select t.ElementReference).ToArray();
 
-            await JsRuntime.InvokeAsync<object>("BlazorMdc.tooltip.init", refs);
+            await JsRuntime.InvokeVoidAsync("BlazorMdc.tooltip.init", refs);
 
             foreach (var t in Tooltips.Where(t => !t.Initiated))
             {

--- a/BlazorMdc/Components/TopAppBar/MTTopAppBar.razor.cs
+++ b/BlazorMdc/Components/TopAppBar/MTTopAppBar.razor.cs
@@ -69,6 +69,6 @@ namespace BlazorMdc
 
 
         /// <inheritdoc/>
-        private protected override async Task InitializeMdcComponent() => await JsRuntime.InvokeAsync<object>("BlazorMdc.topAppBar.init", HeaderElem, ScrollTarget);
+        private protected override async Task InitializeMdcComponent() => await JsRuntime.InvokeVoidAsync("BlazorMdc.topAppBar.init", HeaderElem, ScrollTarget);
     }
 }

--- a/BlazorMdc/Foundation/InputComponentFoundation.cs
+++ b/BlazorMdc/Foundation/InputComponentFoundation.cs
@@ -52,7 +52,7 @@ namespace BlazorMdc.Internal
 
                     if (_hasInstantiated)
                     {
-                        InvokeAsync(async () => await DebouncedOnValueSet());
+                        InvokeAsync(() => DebouncedOnValueSet());
                     }
                     else
                     {


### PR DESCRIPTION
- `InvokeAsync(async () => await ...)` is equivalent with `InvokeAsync(() => ...)`

- `js.InvokeAsync<object>` is functionally equivalent with `js.InvokeVoidAsync` when the return value is ignored (and probably saves a deserialization?)