### PR TITLE
Set default values for MinDate/MaxDate

### DIFF
--- a/Material.Blazor/Components/DatePicker/MBDatePicker.razor.cs
+++ b/Material.Blazor/Components/DatePicker/MBDatePicker.razor.cs
@@ -36,13 +36,13 @@ namespace Material.Blazor
         /// <summary>
         /// Minimum date set by the consumer
         /// </summary>
-        [Parameter] public DateTime MinDate { get; set; }
+        [Parameter] public DateTime MinDate { get; set; } = DateTime.MinValue;
 
 
         /// <summary>
         /// Maximum date set by the consumer
         /// </summary>
-        [Parameter] public DateTime MaxDate { get; set; }
+        [Parameter] public DateTime MaxDate { get; set; } = DateTime.MaxValue;
 
 
         /// <summary>


### PR DESCRIPTION
Without the default values, the user is forced to specify both values, as otherwise the default value for DateTime is set. This is not a problem for MinDate, as it's the same, but for MaxDate, as MaxDate was by default 01/01/0001, meaning no date was selectable.
Setting the default value for MinDate is purely for consistency