### PR TITLE
Add a hint to have the build tasks find NPM

### DIFF
--- a/articles/DevelopmentEnvironment.md
+++ b/articles/DevelopmentEnvironment.md
@@ -25,6 +25,7 @@ We have developed Material.Blazor using Visual Studio 2019 on Windows, and have 
 - To build the Blazor project you need to be using the latest preview version of Visual Studio 2019. This can be found at [https://visualstudio.microsoft.com/vs/preview/](https://visualstudio.microsoft.com/vs/preview/). The Community Edition is sufficient. During the installation you must include the "ASP.NET and web development" Workload using Visual Studio Installer.:
   <img src="../images/vs-config.png" alt="Visual Studio Workloads"></img>
 - Material.Blazor uses SASS for styling and uses Material Components Web SASS mixins, and additionally TypeScript with the Material Components Web's TypeScript. This is the reason you need to select "Node.js development" in the previous step.
+- Unless you have a separate installation of NodeJs on your computer, you may need to add the directory path to npm.cmd to you users OS environment variable PATH. Typically this would be "C:\Program Files (x86)\Microsoft Visual Studio\2019\Preview\MSBuild\Microsoft\VisualStudio\NodeJs", but may depend on the Visual Studio edition and version you're actually using. Make sure to restart Visual Studio after modifying the PATH variable.
 - There are some Visual Studio extensions that you need or may want:
   - We like Markdown Editor, which will help you improve this page.
     <img src="../images/vs-extensions.png" alt="Visual Studio Extensions"></img>


### PR DESCRIPTION
When rebuiling the Material.Blazor.csproj project I got the error code 9009 from the 'npm --version' test call and the comment says "If the return code is 9009, npm is not present" which is the correct hint, but it took some time to understand that the path to NPM isn't automatically added to the PATH var by the VS installer. So I thought it may be worth adding this little note. Or is there a better  way?