### PR TITLE
Make combinations of TopAppBarType possible

### DIFF
--- a/Material.Blazor/Components/TopAppBar/MBTopAppBar.razor.cs
+++ b/Material.Blazor/Components/TopAppBar/MBTopAppBar.razor.cs
@@ -62,8 +62,11 @@ namespace Material.Blazor
 
             ClassMapperInstance
                 .Add("mdc-top-app-bar")
-                .AddIf($"mdc-top-app-bar--{TopAppBarType.ToString().ToLower()}", () => TopAppBarType != MBTopAppBarType.Standard && TopAppBarType != MBTopAppBarType.ShortCollapsed)
-                .AddIf($"mdc-top-app-bar--short mdc-top-app-bar--short-collapsed", () => TopAppBarType == MBTopAppBarType.ShortCollapsed)
+                .AddIf("mdc-top-app-bar--fixed", () => (TopAppBarType & MBTopAppBarType.Fixed) == MBTopAppBarType.Fixed)
+                .AddIf("mdc-top-app-bar--dense", () => (TopAppBarType & MBTopAppBarType.Dense) == MBTopAppBarType.Dense)
+                .AddIf("mdc-top-app-bar--prominent", () => (TopAppBarType & MBTopAppBarType.Prominent) == MBTopAppBarType.Prominent)
+                .AddIf("mdc-top-app-bar--short", () => (TopAppBarType & MBTopAppBarType.Short) == MBTopAppBarType.Short)
+                .AddIf("mdc-top-app-bar--short mdc-top-app-bar--short-collapsed", () => (TopAppBarType & MBTopAppBarType.ShortCollapsed) == MBTopAppBarType.ShortCollapsed)
                 .Add("app-bar");
         }
 

--- a/Material.Blazor/Model/MBEnumerations.cs
+++ b/Material.Blazor/Model/MBEnumerations.cs
@@ -1,4 +1,6 @@
-﻿namespace Material.Blazor
+﻿using System;
+
+namespace Material.Blazor
 {
     /// <summary>
     /// Determines what attributes to splat from <see cref="SplatAttributes"/>. Can be specified with bitwise or, eg:
@@ -653,6 +655,7 @@
     /// <summary>
     /// Material Theme top app bar type applied to an <see cref="MBTopAppBar"/>.
     /// </summary>
+    [Flags]
     public enum MBTopAppBarType
     {
         /// <summary>

--- a/Material.Blazor/Model/MBEnumerations.cs
+++ b/Material.Blazor/Model/MBEnumerations.cs
@@ -661,33 +661,33 @@ namespace Material.Blazor
         /// <summary>
         /// The standard variety.
         /// </summary>
-        Standard,
+        Standard = 0,
 
         /// <summary>
         /// The fixed variety.
         /// </summary>
-        Fixed,
+        Fixed = 1 << 0,
 
 
         /// <summary>
         /// The dense variety.
         /// </summary>
-        Dense,
+        Dense = 1 << 1,
 
         /// <summary>
         /// The prominent variety.
         /// </summary>
-        Prominent,
+        Prominent = 1 << 2,
 
         /// <summary>
         /// The short variety.
         /// </summary>
-        Short,
+        Short = 1 << 3,
 
         /// <summary>
         /// The short collapsed variety.
         /// </summary>
-        ShortCollapsed
+        ShortCollapsed = 1 << 4
     }
 
 


### PR DESCRIPTION
It is valid to create a top app bar with `mdc-top-app-bar--fixed mdc-top-app-bar--dense`, which should correspond to `@(MBTopAppBarType.Fixed | MBTopAppBarType.Dense)`. This currently fails as the class mapping is done by exact comparison / toLower.