### PR TITLE
alternative for disabled days for discussion

### DIFF
--- a/Material.Blazor.Website/Pages/DatePicker.razor
+++ b/Material.Blazor.Website/Pages/DatePicker.razor
@@ -79,7 +79,7 @@
 
                     <p>
                         <MBDatePicker @bind-Value="@Outlined"
-                                      Label="Weekdays Outlined"
+                                      Label="Custom selectable dates"
                                       DateFormat="ddd MMM dd, yyyy"
                                       DateIsSelectable="(date) => date.DayOfWeek is DayOfWeek.Monday or DayOfWeek.Wednesday or DayOfWeek.Friday or DayOfWeek.Sunday"
                                       SelectInputStyle="MBSelectInputStyle.Outlined"

--- a/Material.Blazor/Components/DatePicker/InternalDatePickerDayButton.razor
+++ b/Material.Blazor/Components/DatePicker/InternalDatePickerDayButton.razor
@@ -1,8 +1,11 @@
 ﻿@namespace Material.Blazor.Internal
 @inherits ComponentFoundation
 
+@{ 
+    var classes = $"mb-dp-day-pad__button {(DisplayDate.Month != StartOfDisplayMonth.Month ? "mb-dp-day-pad__button_other_month" : "")}";
+}
 <MBButton ButtonStyle="@ButtonStyle"
-          class="mb-dp-day-pad__button"
+          class="@classes"
           Disabled="@ButtonDisabled"
           Label="@Day"
           @onclick="@OnClickAsync" />

--- a/Material.Blazor/Components/DatePicker/InternalDatePickerDayButton.razor.cs
+++ b/Material.Blazor/Components/DatePicker/InternalDatePickerDayButton.razor.cs
@@ -67,11 +67,6 @@ namespace Material.Blazor.Internal
         {
             get
             {
-                if (DisplayDate.Month != StartOfDisplayMonth.Month)
-                {
-                    return true;
-                }
-
                 if (DateIsSelectable != null && DateIsSelectable != MBDatePicker.DateIsSelectableNotUsed && !DateIsSelectable(DisplayDate))
                 {
                     return true;

--- a/Material.Blazor/Components/DatePicker/MBDatePicker.scss
+++ b/Material.Blazor/Components/DatePicker/MBDatePicker.scss
@@ -165,7 +165,7 @@ $dp-day-pad-weekdays-size: $dp-button-size + $dp-button-margin;
 }
 
 .mb-dp-day-pad__button_other_month {
-    opacity: 0.4;
+    visibility: hidden;
 }
 
 

--- a/Material.Blazor/Components/DatePicker/MBDatePicker.scss
+++ b/Material.Blazor/Components/DatePicker/MBDatePicker.scss
@@ -164,6 +164,10 @@ $dp-day-pad-weekdays-size: $dp-button-size + $dp-button-margin;
     }
 }
 
+.mb-dp-day-pad__button_other_month {
+    opacity: 0.4;
+}
+
 
 /*
     Year pad


### PR DESCRIPTION
This is something for discussion. In my use case, a datepicker doesn't allow picking just any day. It must be two days in the future, but never Sunday or Monday. Right now this is how it looks like:

![image](https://user-images.githubusercontent.com/10850250/109024259-3cc3d000-76c6-11eb-87ce-919eb4d4bd95.png)

This makes the user believe that beyond the 27th, there's no available date. It's wrong though: everything in the next month would be selectable, if only they switched to that month. This is a huge UX issue for my use case.

I propose the following: instead of disabling the buttons if they don't lie within the viewed month, simply reduce their opacity.

| before  |   after	|
|---	|---	|
|   ![image](https://user-images.githubusercontent.com/10850250/109024686-b065dd00-76c6-11eb-93a2-194f55770a22.png)	|   ![image](https://user-images.githubusercontent.com/10850250/109024492-81e80200-76c6-11eb-81a2-f1c83c7eb3b1.png)	|
|   ![image](https://user-images.githubusercontent.com/10850250/109024717-b78ceb00-76c6-11eb-8f5a-62885acf429b.png)	|   ![image](https://user-images.githubusercontent.com/10850250/109024567-92987800-76c6-11eb-915b-8ec40f290127.png)	|
|   ![image](https://user-images.githubusercontent.com/10850250/109024749-bd82cc00-76c6-11eb-89d6-d66c687122ec.png)	|   ![image](https://user-images.githubusercontent.com/10850250/109024610-9b894980-76c6-11eb-9d2f-9f0d9b48af5f.png)	|
