### PR TITLE
moved SASS code from lib to website

### DIFF
--- a/Material.Blazor.Website/Styles/app.scss
+++ b/Material.Blazor.Website/Styles/app.scss
@@ -2,6 +2,8 @@
 @use "@material/top-app-bar";
 
 
+@use 'sass:color';
+
 @mixin app-classes() {
     /*
      * App layout styling
@@ -11,6 +13,42 @@
         margin: 0 !important;
         background-color: theme.$background;
         color: theme.$on-surface;
+    }
+
+
+    :root {
+        --mb-scroll-color: var(--mdc-theme-primary);
+        --mb-scroll-track-color: rgba(0, 0, 0, 0);
+        --mb-scrollbar-width: thin;
+        --mb-scroll-webkit-margin-right: 4px;
+        --mb-scroll-webkit-width: 8px;
+        --mb-scroll-webkit-border-radius: 4px;
+    }
+
+
+    .mb-custom-scrollbars {
+        scrollbar-width: var(--mb-scrollbar-width);
+        scrollbar-color: var(--mb-scroll-color) var(--mb-scroll-track-color);
+        /* Scrollbar width */
+        ::-webkit-scrollbar {
+            width: var(--mb-scroll-webkit-width);
+            height: var(--mb-scroll-webkit-width);
+        }
+        /* Track */
+        ::-webkit-scrollbar-track {
+            background-color: var(--mb-scroll-track-color);
+            margin-right: var(--mb-scroll-webkit-margin-right);
+        }
+        /* Handle */
+        ::-webkit-scrollbar-thumb {
+            background: var(--mb-scroll-color);
+            border-radius: var(--mb-scroll-webkit-border-radius);
+        }
+    }
+
+    .mb-custom-scrollbars * {
+        scrollbar-width: inherit;
+        scrollbar-color: inherit;
     }
 
     app {

--- a/Material.Blazor/Styles/MaterialBlazor.scss
+++ b/Material.Blazor/Styles/MaterialBlazor.scss
@@ -2,8 +2,6 @@
 
 @use "../wwwroot/material-components-icons.css";
 
-@use '_colors.scss';
-
 @use '../Components/AutocompleteTextField/MBAutocompleteTextField.scss';
 @use '../Components/BladeSet/MBBladeSet.scss';
 @use '../Components/Button/MBButton.scss';
@@ -27,45 +25,6 @@
 @use '../Components/TextField/MBTextField.scss';
 @use '../Components/Toast/MBToast.scss';
 @use '../Components/TopAppBar/MBTopAppBar.scss';
-
-@use 'sass:color';
-
-
-:root {
-    --mb-scroll-color: var(--mdc-theme-primary);
-    --mb-scroll-track-color: rgba(0, 0, 0, 0);
-    --mb-scrollbar-width: thin;
-    --mb-scroll-webkit-margin-right: 4px;
-    --mb-scroll-webkit-width: 8px;
-    --mb-scroll-webkit-border-radius: 4px;
-}
-
-
-.mb-custom-scrollbars {
-    scrollbar-width: var(--mb-scrollbar-width);
-    scrollbar-color: var(--mb-scroll-color) var(--mb-scroll-track-color);
-
-    /* Scrollbar width */
-    ::-webkit-scrollbar {
-        width: var(--mb-scroll-webkit-width);
-        height: var(--mb-scroll-webkit-width);
-    }
-    /* Track */
-    ::-webkit-scrollbar-track {
-        background-color: var(--mb-scroll-track-color);
-        margin-right: var(--mb-scroll-webkit-margin-right);
-    }
-    /* Handle */
-    ::-webkit-scrollbar-thumb {
-        background: var(--mb-scroll-color);
-        border-radius: var(--mb-scroll-webkit-border-radius);
-    }
-}
-
-.mb-custom-scrollbars * {
-    scrollbar-width: inherit;
-    scrollbar-color: inherit;
-}
 
 
 .mb-align-left {


### PR DESCRIPTION
I noticed that there is some SASS code in `MaterialBlazor.scss` that styles the scrollbar on the website. This is an attempt to move that SASS code to the `app.scss` in the website project. Please confirm the correctness of this before merging...

Side effect: Reduces `MaterialBlazor.min.css` from 182KB to 159KB.