### PR TITLE
more permissive global.json

### DIFF
--- a/global.json
+++ b/global.json
@@ -2,6 +2,6 @@
   "sdk": {
     "version": "5.0.100",
     "allowPrerelease": false,
-    "rollForward": "latestMajor"
+    "rollForward": "latestMinor"
   }
 }

--- a/global.json
+++ b/global.json
@@ -1,7 +1,7 @@
 {
   "sdk": {
-    "version": "5.0.100",
+    "version": "5.0.200",
     "allowPrerelease": false,
-    "rollForward": "feature"
+    "rollForward": "latestMajor"
   }
 }

--- a/global.json
+++ b/global.json
@@ -1,6 +1,6 @@
 {
   "sdk": {
-    "version": "5.0.200",
+    "version": "5.0.100",
     "allowPrerelease": false,
     "rollForward": "latestMajor"
   }


### PR DESCRIPTION
From the docs (https://docs.microsoft.com/en-us/dotnet/core/tools/global-json?tabs=netcore3x):

### `feature`

> Uses the latest patch level for the specified major, minor, and feature band.
> If not found, rolls forward to the next higher feature band within the same major/minor and uses the latest patch level for that feature band.
> If not found, fails.

### `latestMajor`

> Uses the highest installed .NET SDK with a version that is greater or equal than the specified value.
> If not found, fail.


To me, `latestMajor` feels like a better choice, but I'll leave the ultimate decision up to @MarkStega 