### PR TITLE
Datepicker

### DIFF
--- a/Material.Blazor.Website/Pages/DatePicker.razor
+++ b/Material.Blazor.Website/Pages/DatePicker.razor
@@ -119,10 +119,10 @@
                             }
                         </style>
                         <MBDatePicker @bind-Value="@Outlined"
-                                      Label="Custom selectable dates"
+                                      Label="Custom style"
                                       class="custom-style"
                                       DateFormat="ddd MMM dd, yyyy"
-                                      DateIsSelectable="(date) => date.DayOfWeek is DayOfWeek.Monday or DayOfWeek.Wednesday or DayOfWeek.Friday or DayOfWeek.Sunday"
+                                      DateSelectionCriteria="MBDateSelectionCriteria.WeekdaysOnly"
                                       SelectInputStyle="MBSelectInputStyle.Outlined"
                                       MaxDate="@Max"
                                       MenuSurfacePositioning="@MBMenuSurfacePositioning.Fixed"

--- a/Material.Blazor.Website/Pages/DatePicker.razor
+++ b/Material.Blazor.Website/Pages/DatePicker.razor
@@ -90,6 +90,47 @@
                 </Primary>
             </MBCard>
         </div>
+
+        <div class="mdc-layout-grid__cell--span-4">
+            <MBCard AutoStyled="true">
+                <Primary>
+                    <h2 class="mb-card__title mdc-typography mdc-typography--headline6">
+                        Custom style
+                    </h2>
+
+                    <h3 class="mb-card__subtitle mdc-typography mdc-typography--subtitle2">
+                        In a typical month, the first day of that month doesn't coincide with the first day of the week.
+                        Similarly, the last week of a month will usually end with a few days in the next month.
+
+                        By default, this date picker component will not show these days. You can override this behavior by overriding the CSS classes <code>mb-dp-day-pad__button_earlier_month</code> and <code>mb-dp-day-pad__button_later_month</code>.
+                    </h3>
+
+                    <p>
+                        <style>
+                            .custom-style .mb-dp-day-pad__button_earlier_month {
+                                opacity: .3;
+                                visibility: unset !important;
+                                font-style: italic;
+                            }
+
+                            .custom-style .mb-dp-day-pad__button_later_month {
+                                opacity: .7;
+                                visibility: unset !important;
+                            }
+                        </style>
+                        <MBDatePicker @bind-Value="@Outlined"
+                                      Label="Custom selectable dates"
+                                      class="custom-style"
+                                      DateFormat="ddd MMM dd, yyyy"
+                                      DateIsSelectable="(date) => date.DayOfWeek is DayOfWeek.Monday or DayOfWeek.Wednesday or DayOfWeek.Friday or DayOfWeek.Sunday"
+                                      SelectInputStyle="MBSelectInputStyle.Outlined"
+                                      MaxDate="@Max"
+                                      MenuSurfacePositioning="@MBMenuSurfacePositioning.Fixed"
+                                      MinDate="@Min" />
+                    </p>
+                </Primary>
+            </MBCard>
+        </div>
     </PageContent>
 </DemonstrationPage>
 

--- a/Material.Blazor/Components/DatePicker/InternalDatePickerDayButton.razor
+++ b/Material.Blazor/Components/DatePicker/InternalDatePickerDayButton.razor
@@ -1,8 +1,13 @@
 ﻿@namespace Material.Blazor.Internal
 @inherits ComponentFoundation
 
-@{ 
-    var classes = $"mb-dp-day-pad__button {(DisplayDate.Month != StartOfDisplayMonth.Month ? "mb-dp-day-pad__button_other_month" : "")}";
+@{
+    var classes = DisplayDate.Month.CompareTo(StartOfDisplayMonth.Month) switch
+    {
+        -1 => "mb-dp-day-pad__button mb-dp-day-pad__button_earlier_month",
+        1 => "mb-dp-day-pad__button mb-dp-day-pad__button_later_month",
+        _ => "mb-dp-day-pad__button",
+    };
 }
 <MBButton ButtonStyle="@ButtonStyle"
           class="@classes"

--- a/Material.Blazor/Components/DatePicker/MBDatePicker.scss
+++ b/Material.Blazor/Components/DatePicker/MBDatePicker.scss
@@ -164,7 +164,10 @@ $dp-day-pad-weekdays-size: $dp-button-size + $dp-button-margin;
     }
 }
 
-.mb-dp-day-pad__button_other_month {
+.mb-dp-day-pad__button_earlier_month {
+    visibility: hidden;
+}
+.mb-dp-day-pad__button_later_month {
     visibility: hidden;
 }
 


### PR DESCRIPTION
Thanks @MarkStega for merging #408. This PR would enable different customization for the earlier/later month segments of the component. By default, it stays exactly the same as in #408.

Default:
![image](https://user-images.githubusercontent.com/10850250/110330726-cc527280-8026-11eb-9503-ed198be7e301.png)

Custom:
![image](https://user-images.githubusercontent.com/10850250/110330761-d4aaad80-8026-11eb-992e-a906333b8219.png)
