### PR TITLE
Always build the current version

### DIFF
--- a/.github/workflows/GithubActionsWIP.yml
+++ b/.github/workflows/GithubActionsWIP.yml
@@ -126,6 +126,7 @@ jobs:
 ############################################################################################################
   deployghpages:
     needs: [buildmaterialblazor]
+    if: github.event_name != 'pull_request' # for PRs, we only need to make sure the build works (the job above), we don't need to deploy anything.
 
     runs-on: ubuntu-latest
 
@@ -162,7 +163,7 @@ jobs:
         ACCESS_TOKEN: ${{secrets.GH_PAT}}
         BRANCH: gh-pages
         FOLDER: 'deployroot'
-        repository-name: Material-Blazor/Material.Blazor.Current
+        REPOSITORY_NAME: Material-Blazor/Material.Blazor.Current
       if: (github.repository == 'Material-Blazor/Material.Blazor')
 
     # this step rewrites the base href when we are NOT in the main repo

--- a/.github/workflows/GithubActionsWIP.yml
+++ b/.github/workflows/GithubActionsWIP.yml
@@ -79,14 +79,12 @@ jobs:
       run: .\docfx\docfx docfx.json
       env:
         DOCFX_SOURCE_BRANCH_NAME: main
-      if: (github.repository != 'Material-Blazor/Material.Blazor')
 
     - name: Upload Documentation Artifacts 🔺 # The project is then uploaded as an artifact named 'siteDocFx'.
       uses: actions/upload-artifact@v1
       with:
         name: siteDocFx
         path: siteDocFx
-      if: (github.repository != 'Material-Blazor/Material.Blazor')
 
     - name: Build Website 🔧
       run: dotnet build --configuration ${env:buildConfiguration} --version-suffix ${env:ciSuffix} ${env:projectWeb}
@@ -99,7 +97,6 @@ jobs:
       with:
         name: siteWeb
         path: siteWeb
-      if: (github.repository != 'Material-Blazor/Material.Blazor')
 
     - name: Generate the first NuGet package 🔧
       run: dotnet pack --no-build --configuration ${env:buildConfiguration} --output ${env:outputMB} -p:IncludeSymbols=true -p:SymbolPackageFormat=snupkg --version-suffix ${env:ciSuffix} ${env:projectMB}
@@ -135,25 +132,40 @@ jobs:
     steps:
     - name: Checkout repository under $GITHUB_WORKSPACE so the job can access it 🛎️
       uses: actions/checkout@v2
-      if: (github.repository != 'Material-Blazor/Material.Blazor')
 #      if: (github.repository != 'Material-Blazor/Material.Blazor') && contains(github.ref, 'refs/heads')
 
     - name: Download Artifacts 🔻 # The built project is downloaded into the 'site' folder.
       uses: actions/download-artifact@v1
       with:
         name: siteDocFx
-      if: (github.repository != 'Material-Blazor/Material.Blazor')
 
     - name: Download Artifacts 🔻 # The built project is downloaded into the 'site' folder.
       uses: actions/download-artifact@v1
       with:
         name: siteWeb
-      if: (github.repository != 'Material-Blazor/Material.Blazor')
 
     - name: Configure deployment directory structure Ꙫ
       run: mv siteWeb/wwwroot deployroot; mv siteDocFx deployroot/docs
-      if: (github.repository != 'Material-Blazor/Material.Blazor')
 
+    # this step rewrites the base href when we are in the main repo and about to deploy to the Material.Blazor.Current repo
+    - name: Base Href Rewrite 👉
+      uses: SteveSandersonMS/ghaction-rewrite-base-href@v1
+      with:
+        html_path: 'deployroot/index.html'
+        base_href: '/Material.Blazor.Current/'
+      if: (github.repository == 'Material-Blazor/Material.Blazor')
+
+    # this step deploys to Material-Blazor/Material.Blazor.Current when we are in the main repo
+    - name: Deploy 🚀
+      uses: JamesIves/github-pages-deploy-action@releases/v3
+      with:
+        ACCESS_TOKEN: ${{secrets.GH_PAT}}
+        BRANCH: gh-pages
+        FOLDER: 'deployroot'
+        repository-name: Material-Blazor/Material.Blazor.Current
+      if: (github.repository == 'Material-Blazor/Material.Blazor')
+
+    # this step rewrites the base href when we are NOT in the main repo
     - name: Base Href Rewrite 👉
       uses: SteveSandersonMS/ghaction-rewrite-base-href@v1
       with:
@@ -161,6 +173,7 @@ jobs:
         base_href: '/Material.Blazor/'
       if: (github.repository != 'Material-Blazor/Material.Blazor')
 
+    # this step deploys to the current repo's gh-pages branch when we are NOT in the main repo
     - name: Deploy 🚀
       uses: JamesIves/github-pages-deploy-action@releases/v3
       with:


### PR DESCRIPTION
This change is supposed to achieve the following:
- Let the material-blazor.com website be built as before: only on release with the separate workflow.
- On a fork, build & deploy the current version (i.e. state of main) as before.
- On the main repo, now also build the website on any change to the main branch, but don't deploy to material-blazor.com, but to a separate repo (Material.Blazor.Current)