### PR TITLE
Dialog JS simplification

### DIFF
--- a/Material.Blazor/Components/Dialog/MBDialog.razor.cs
+++ b/Material.Blazor/Components/Dialog/MBDialog.razor.cs
@@ -209,6 +209,13 @@ namespace Material.Blazor
             await Task.CompletedTask;
         }
 
+        [JSInvokable("NotifyClosed")]
+        public void NotifyClosed(string reason)
+        {
+            Tcs?.SetResult(reason);
+            IsOpen = false;
+        }
+
 
         /// <summary>
         /// Shows the dialog on the next render after a show action. Also on the next render after the dialog is initiated each
@@ -225,8 +232,7 @@ namespace Material.Blazor
                 try
                 {
                     AfterRenderShowAction = false;
-                    Tcs.SetResult(await JsRuntime.InvokeAsync<string>("MaterialBlazor.MBDialog.show", DialogElem, ObjectReference, EscapeKeyAction, ScrimClickAction));
-                    IsOpen = false;
+                    await JsRuntime.InvokeVoidAsync("MaterialBlazor.MBDialog.show", DialogElem, ObjectReference, EscapeKeyAction, ScrimClickAction);
                     StateHasChanged();
                 }
                 catch

--- a/Material.Blazor/Components/Dialog/MBDialog.ts
+++ b/Material.Blazor/Components/Dialog/MBDialog.ts
@@ -15,16 +15,13 @@ export function show(elem, dotNetObject, escapeKeyAction, scrimClickAction): any
     dialog.escapeKeyAction = escapeKeyAction;
     dialog.scrimClickAction = scrimClickAction;
 
-    return new Promise(resolve => {
+    const closingCallback = event => {
+        dialog.unlisten('MDCDialog:closing', closingCallback);
+        dotNetObject.invokeMethodAsync('NotifyClosed', event.detail.action);
+    };
 
-        const closingCallback = event => {
-            dialog.unlisten('MDCDialog:closing', closingCallback);
-            resolve(event.detail.action);
-        };
-
-        dialog.listen('MDCDialog:closing', closingCallback);
-        dialog.open();
-    });
+    dialog.listen('MDCDialog:closing', closingCallback);
+    dialog.open();
 }
 
 export function hide(elem, dialogAction) {


### PR DESCRIPTION
opening the dialog will return quickly now; the closing event will now simply invoke NotifyClosed, which sets the result of the ShowAsync method.