### PR TITLE
Added English business days to date picker examples

### DIFF
--- a/Material.Blazor.Website/Material.Blazor.Website.csproj
+++ b/Material.Blazor.Website/Material.Blazor.Website.csproj
@@ -40,6 +40,7 @@
   <ItemGroup>
     <PackageReference Include="Microsoft.AspNetCore.Components" Version="5.0.4" />
     <PackageReference Include="Microsoft.AspNetCore.Components.Web" Version="5.0.4" />
+    <PackageReference Include="Nager.Date" Version="1.28.2" />
     <PackageReference Include="System.Net.Http.Json" Version="5.0.0" />
   </ItemGroup>
 

--- a/Material.Blazor.Website/Pages/DatePicker.razor
+++ b/Material.Blazor.Website/Pages/DatePicker.razor
@@ -2,6 +2,8 @@
 
 @inject IMBToastService ToastService
 
+@using Nager.Date
+
 
 
 <DemonstrationPage ComponentName="DatePicker"
@@ -74,14 +76,25 @@
                     </h2>
 
                     <h3 class="mb-card__subtitle mdc-typography mdc-typography--subtitle2">
-                        Control which dates are selectable.
+                        Control which dates are selectable, first with Mondays, Wednesdays and Fridays and second with business days in England, using the <a href="https://www.nuget.org/packages/Nager.Date/" target="_blank">Nager.Date nuget package</a>.
                     </h3>
 
                     <p>
-                        <MBDatePicker @bind-Value="@Outlined"
-                                      Label="Custom selectable dates"
+                        <MBDatePicker @bind-Value="@MonWedFri"
+                                      Label="Mon, Wed, or Fri"
                                       DateFormat="ddd MMM dd, yyyy"
-                                      DateIsSelectable="(date) => date.DayOfWeek is DayOfWeek.Monday or DayOfWeek.Wednesday or DayOfWeek.Friday or DayOfWeek.Sunday"
+                                      DateIsSelectable="(date) => date.DayOfWeek is DayOfWeek.Monday or DayOfWeek.Wednesday or DayOfWeek.Friday"
+                                      SelectInputStyle="MBSelectInputStyle.Outlined"
+                                      MaxDate="@Max"
+                                      MenuSurfacePositioning="@MBMenuSurfacePositioning.Fixed"
+                                      MinDate="@Min" />
+                    </p>
+
+                    <p>
+                        <MBDatePicker @bind-Value="@EnglandBusinessDay"
+                                      Label="England Business Day"
+                                      DateFormat="ddd MMM dd, yyyy"
+                                      DateIsSelectable="@((date) => !DateSystem.IsPublicHoliday(date, CountryCode.GB, "GB-ENG") && !DateSystem.IsWeekend(date, CountryCode.GB))"
                                       SelectInputStyle="MBSelectInputStyle.Outlined"
                                       MaxDate="@Max"
                                       MenuSurfacePositioning="@MBMenuSurfacePositioning.Fixed"
@@ -118,7 +131,7 @@
                                 visibility: unset !important;
                             }
                         </style>
-                        <MBDatePicker @bind-Value="@Outlined"
+                        <MBDatePicker @bind-Value="@CustomStyle"
                                       Label="Custom style"
                                       class="custom-style"
                                       DateFormat="ddd MMM dd, yyyy"
@@ -159,6 +172,45 @@
             _outlined = value;
 
             ToastService.ShowToast(heading: "Outlined Date Picker", message: $"Value: {_outlined.ToLongDateString()}", level: MBToastLevel.Success, showIcon: false);
+        }
+    }
+
+
+    private DateTime _monWedFri = new DateTime(2021, 1, 8);
+    private DateTime MonWedFri
+    {
+        get => _monWedFri;
+        set
+        {
+            _monWedFri = value;
+
+            ToastService.ShowToast(heading: "Mon, Wed, Fri selectable", message: $"Value: {_monWedFri.ToLongDateString()}", level: MBToastLevel.Success, showIcon: false);
+        }
+    }
+
+
+    private DateTime _englandBusinessDay = new DateTime(2021, 4, 6);
+    private DateTime EnglandBusinessDay
+    {
+        get => _englandBusinessDay;
+        set
+        {
+            _englandBusinessDay = value;
+
+            ToastService.ShowToast(heading: "England Business Day selectable", message: $"Value: {_englandBusinessDay.ToLongDateString()}", level: MBToastLevel.Success, showIcon: false);
+        }
+    }
+
+
+    private DateTime _customStyle = new DateTime(2021, 1, 8);
+    private DateTime CustomStyle
+    {
+        get => _customStyle;
+        set
+        {
+            _customStyle = value;
+
+            ToastService.ShowToast(heading: "Custom Style", message: $"Value: {_customStyle.ToLongDateString()}", level: MBToastLevel.Success, showIcon: false);
         }
     }
 


### PR DESCRIPTION
@MarkStega and @stefanloerwald this is a very minor, presentational PR. Just a minor upgrade to the datepicker website page to add a further example of using selectable dates with the Nager.Date nuget package. This is very low impact and can wait indefinitely until one of you feels inclined to do a quick review.