### PR TITLE
Adds MBBatchingWrapper and removes timer from BatchingJSRuntime

### DIFF
--- a/Material.Blazor.Website/Shared/DemonstrationPage.razor
+++ b/Material.Blazor.Website/Shared/DemonstrationPage.razor
@@ -1,48 +1,50 @@
 ﻿<div @key="@CascadingDefaults" class="mdc-layout-grid__cell--span-12">
     <MBCard>
         <Primary>
-            <div class="mb-card__autostyled">
-                <h2 class="mb-card__title mdc-typography--headline4">@Title</h2>
-            </div>
-            <div class="mb-card__secondary">
-                @Description
+            <MBBatchingWrapper>
+                <div class="mb-card__autostyled">
+                    <h2 class="mb-card__title mdc-typography--headline4">@Title</h2>
+                </div>
+                <div class="mb-card__secondary">
+                    @Description
 
-                @if (NeedsTable)
-                {
-                    <p style="overflow: auto;">
-                        <MBDataTable Items="@Items"
-                                     Context="item"
-                                     class="dr-table">
-                            <TableHeader>
-                                <th class="mdc-data-table__header-cell" role="columnheader" scope="col">Reference</th>
-                                <th class="mdc-data-table__header-cell" role="columnheader" scope="col">Link Source</th>
-                            </TableHeader>
+                    @if (NeedsTable)
+                    {
+                        <p style="overflow: auto;">
+                            <MBDataTable Items="@Items"
+                                         Context="item"
+                                         class="dr-table">
+                                <TableHeader>
+                                    <th class="mdc-data-table__header-cell" role="columnheader" scope="col">Reference</th>
+                                    <th class="mdc-data-table__header-cell" role="columnheader" scope="col">Link Source</th>
+                                </TableHeader>
 
-                            <TableRow>
-                                <td class="mdc-data-table__cell">@item.Title</td>
-                                <td class="mdc-data-table__cell">@item.ContentMarkup</td>
-                            </TableRow>
-                        </MBDataTable>
-                    </p>
-                }
+                                <TableRow>
+                                    <td class="mdc-data-table__cell">@item.Title</td>
+                                    <td class="mdc-data-table__cell">@item.ContentMarkup</td>
+                                </TableRow>
+                            </MBDataTable>
+                        </p>
+                    }
 
-                @if (RequiresDisableSelection)
-                {
-                    <p>
-                        <MBSwitch @bind-Value="@CascadingDefaults.Disabled" Label="Disable Components" />
-                    </p>
-                }
+                    @if (RequiresDisableSelection)
+                    {
+                        <p>
+                            <MBSwitch @bind-Value="@CascadingDefaults.Disabled" Label="Disable Components" />
+                        </p>
+                    }
 
-                @if (MinDensity != MBDensity.Default)
-                {
-                    <p>
-                        <MBRadioButtonGroup @bind-Value="@CascadingDefaults.ThemeDensity"
-                                            Items="@Densities" />
-                    </p>
-                }
+                    @if (MinDensity != MBDensity.Default)
+                    {
+                        <p>
+                            <MBRadioButtonGroup @bind-Value="@CascadingDefaults.ThemeDensity"
+                                                Items="@Densities" />
+                        </p>
+                    }
 
-                @Controls
-            </div>
+                    @Controls
+                </div>
+            </MBBatchingWrapper>
         </Primary>
     </MBCard>
 </div>

--- a/Material.Blazor/Components/AutocompleteTextField/MBAutocompleteTextField.razor.cs
+++ b/Material.Blazor/Components/AutocompleteTextField/MBAutocompleteTextField.razor.cs
@@ -342,7 +342,7 @@ namespace Material.Blazor
             if (!IsOpen || forceOpen)
             {
                 IsOpen = true;
-                await JsRuntime.InvokeVoidAsync("MaterialBlazor.MBAutoCompleteTextField.open", MenuReference);
+                await InvokeJSVoidAsync("MaterialBlazor.MBAutoCompleteTextField.open", MenuReference);
             }
         }
 
@@ -352,12 +352,12 @@ namespace Material.Blazor
             if (IsOpen || forceClose)
             {
                 IsOpen = false;
-                await JsRuntime.InvokeVoidAsync("MaterialBlazor.MBAutoCompleteTextField.close", MenuReference);
+                await InvokeJSVoidAsync("MaterialBlazor.MBAutoCompleteTextField.close", MenuReference);
             }
         }
 
 
         /// <inheritdoc/>
-        private protected override Task InstantiateMcwComponent() => JsRuntime.InvokeVoidAsync("MaterialBlazor.MBAutoCompleteTextField.init", TextField.ElementReference, MenuReference, ObjectReference);
+        private protected override Task InstantiateMcwComponent() => InvokeJSVoidAsync("MaterialBlazor.MBAutoCompleteTextField.init", TextField.ElementReference, MenuReference, ObjectReference);
     }
 }

--- a/Material.Blazor/Components/BatchingWrapper/MBBatchingWrapper.razor
+++ b/Material.Blazor/Components/BatchingWrapper/MBBatchingWrapper.razor
@@ -1,0 +1,6 @@
+﻿@namespace Material.Blazor
+
+
+<CascadingValue Value="this" IsFixed="true">
+    @ChildContent
+</CascadingValue>

--- a/Material.Blazor/Components/BatchingWrapper/MBBatchingWrapper.razor.cs
+++ b/Material.Blazor/Components/BatchingWrapper/MBBatchingWrapper.razor.cs
@@ -1,0 +1,44 @@
+﻿using Material.Blazor.Internal;
+using Microsoft.AspNetCore.Components;
+using System;
+using System.Collections.Generic;
+using System.Linq;
+using System.Text;
+using System.Threading.Tasks;
+
+namespace Material.Blazor
+{
+    public partial class MBBatchingWrapper : ComponentBase
+    {
+        [Inject] private IBatchingJSRuntime InjectedJsRuntime { get; set; }
+        protected IBatchingJSRuntime BatchingJsRuntime { get; set; }
+        [CascadingParameter] private MBDialog ParentDialog { get; set; }
+
+
+        /// <summary>
+        /// Gets a value for the component's 'id' attribute.
+        /// </summary>
+        internal readonly string CrossReferenceId = Utilities.GenerateUniqueElementName();
+
+
+        /// <summary>
+        /// The child content containing Material.Blazor components whose JS Interop calls are to be batched.
+        /// </summary>
+        [Parameter] public RenderFragment ChildContent { get; set; }
+
+
+        protected override async Task OnInitializedAsync()
+        {
+            await base.OnInitializedAsync();
+
+            BatchingJsRuntime = ParentDialog == null ? InjectedJsRuntime : new DialogAwareBatchingJSRuntime(InjectedJsRuntime, ParentDialog);
+        }
+
+        protected override async Task OnAfterRenderAsync(bool firstRender)
+        {
+            await base.OnAfterRenderAsync(firstRender);
+
+            await BatchingJsRuntime.FlushBatch(this);
+        }
+    }
+}

--- a/Material.Blazor/Components/BatchingWrapper/MBBatchingWrapper.razor.cs
+++ b/Material.Blazor/Components/BatchingWrapper/MBBatchingWrapper.razor.cs
@@ -1,9 +1,5 @@
 ﻿using Material.Blazor.Internal;
 using Microsoft.AspNetCore.Components;
-using System;
-using System.Collections.Generic;
-using System.Linq;
-using System.Text;
 using System.Threading.Tasks;
 
 namespace Material.Blazor
@@ -25,6 +21,17 @@ namespace Material.Blazor
         /// The child content containing Material.Blazor components whose JS Interop calls are to be batched.
         /// </summary>
         [Parameter] public RenderFragment ChildContent { get; set; }
+
+
+        /// <summary>
+        /// Invokes SHC.
+        /// </summary>
+        /// <returns></returns>
+        internal void InvokeStateHasChanged()
+        {
+            //return InvokeAsync(StateHasChanged);
+            StateHasChanged();
+        }
 
 
         protected override async Task OnInitializedAsync()

--- a/Material.Blazor/Components/BladeSet/MBBladeSet.razor.cs
+++ b/Material.Blazor/Components/BladeSet/MBBladeSet.razor.cs
@@ -1,6 +1,6 @@
-﻿using Material.Blazor.Internal;
-using Microsoft.AspNetCore.Components;
+﻿using Microsoft.AspNetCore.Components;
 using Microsoft.Extensions.Logging;
+using Microsoft.JSInterop;
 using System;
 using System.Collections.Concurrent;
 using System.Collections.Generic;
@@ -20,7 +20,7 @@ namespace Material.Blazor
         private const int transitionMs = 200;
 
         [Inject] private ILogger<MBBladeSet> Logger { get; set; }
-        [Inject] private IBatchingJSRuntime JsRuntime { get; set; }
+        [Inject] private IJSRuntime JsRuntime { get; set; }
 
 
         /// <summary>

--- a/Material.Blazor/Components/Button/MBButton.razor.cs
+++ b/Material.Blazor/Components/Button/MBButton.razor.cs
@@ -92,6 +92,6 @@ namespace Material.Blazor
 
 
         /// <inheritdoc/>
-        private protected override Task InstantiateMcwComponent() => JsRuntime.InvokeVoidAsync("MaterialBlazor.MBButton.init", ElementReference);
+        private protected override Task InstantiateMcwComponent() => InvokeJSVoidAsync("MaterialBlazor.MBButton.init", ElementReference);
     }
 }

--- a/Material.Blazor/Components/Card/MBCard.razor.cs
+++ b/Material.Blazor/Components/Card/MBCard.razor.cs
@@ -93,6 +93,6 @@ namespace Material.Blazor
 
 
         /// <inheritdoc/>
-        private protected override Task InstantiateMcwComponent() => PrimaryAction != null ? JsRuntime.InvokeVoidAsync("MaterialBlazor.MBCard.init", PrimaryActionReference) : Task.CompletedTask;
+        private protected override Task InstantiateMcwComponent() => PrimaryAction != null ? InvokeJSVoidAsync("MaterialBlazor.MBCard.init", PrimaryActionReference) : Task.CompletedTask;
     }
 }

--- a/Material.Blazor/Components/Checkbox/MBCheckbox.razor.cs
+++ b/Material.Blazor/Components/Checkbox/MBCheckbox.razor.cs
@@ -53,7 +53,7 @@ namespace Material.Blazor
 
         private Task UpdateIndeterminateStateAsync()
         {
-            return JsRuntime.InvokeVoidAsync("MaterialBlazor.MBCheckbox.setIndeterminate", ElementReference, IsIndeterminate);
+            return InvokeJSVoidAsync("MaterialBlazor.MBCheckbox.setIndeterminate", ElementReference, IsIndeterminate);
         }
 
         /// <summary>
@@ -99,7 +99,7 @@ namespace Material.Blazor
         /// </summary>
         /// <param name="sender"></param>
         /// <param name="e"></param>
-        protected void OnValueSetCallback() => InvokeAsync(() => JsRuntime.InvokeVoidAsync("MaterialBlazor.MBCheckbox.setChecked", ElementReference, Value));
+        protected void OnValueSetCallback() => InvokeAsync(() => InvokeJSVoidAsync("MaterialBlazor.MBCheckbox.setChecked", ElementReference, Value));
 
 
         /// <summary>
@@ -107,10 +107,10 @@ namespace Material.Blazor
         /// </summary>
         /// <param name="sender"></param>
         /// <param name="e"></param>
-        protected void OnDisabledSetCallback() => InvokeAsync(() => JsRuntime.InvokeVoidAsync("MaterialBlazor.MBCheckbox.setDisabled", ElementReference, AppliedDisabled));
+        protected void OnDisabledSetCallback() => InvokeAsync(() => InvokeJSVoidAsync("MaterialBlazor.MBCheckbox.setDisabled", ElementReference, AppliedDisabled));
 
 
         /// <inheritdoc/>
-        private protected override Task InstantiateMcwComponent() => JsRuntime.InvokeVoidAsync("MaterialBlazor.MBCheckbox.init", ElementReference, FormReference, ComponentValue, IsIndeterminate);
+        private protected override Task InstantiateMcwComponent() => InvokeJSVoidAsync("MaterialBlazor.MBCheckbox.init", ElementReference, FormReference, ComponentValue, IsIndeterminate);
     }
 }

--- a/Material.Blazor/Components/ChipsSelectMulti/MBChipsSelectMulti.razor.cs
+++ b/Material.Blazor/Components/ChipsSelectMulti/MBChipsSelectMulti.razor.cs
@@ -130,7 +130,7 @@ namespace Material.Blazor
         /// </summary>
         /// <param name="sender"></param>
         /// <param name="e"></param>
-        protected void OnValueSetCallback() => InvokeAsync(() => JsRuntime.InvokeVoidAsync("MaterialBlazor.MBChipsSelectMulti.setSelected", ChipsReference, Items.Select(x => Value.Contains(x.SelectedValue)).ToArray()));
+        protected void OnValueSetCallback() => InvokeAsync(() => InvokeJSVoidAsync("MaterialBlazor.MBChipsSelectMulti.setSelected", ChipsReference, Items.Select(x => Value.Contains(x.SelectedValue)).ToArray()));
 
 
         /// <summary>
@@ -138,11 +138,11 @@ namespace Material.Blazor
         /// </summary>
         /// <param name="sender"></param>
         /// <param name="e"></param>
-        protected void OnDisabledSetCallback() => InvokeAsync(() => JsRuntime.InvokeVoidAsync("MaterialBlazor.MBChipsSelectMulti.setDisabled", ChipsReference, AppliedDisabled));
+        protected void OnDisabledSetCallback() => InvokeAsync(() => InvokeJSVoidAsync("MaterialBlazor.MBChipsSelectMulti.setDisabled", ChipsReference, AppliedDisabled));
 
 
         /// <inheritdoc/>
-        private protected override Task InstantiateMcwComponent() => JsRuntime.InvokeVoidAsync("MaterialBlazor.MBChipsSelectMulti.init", ChipsReference, IsSingleSelect, ObjectReference);
+        private protected override Task InstantiateMcwComponent() => InvokeJSVoidAsync("MaterialBlazor.MBChipsSelectMulti.init", ChipsReference, IsSingleSelect, ObjectReference);
 
 
         /// <summary>

--- a/Material.Blazor/Components/CircularProgress/MBCircularProgress.razor.cs
+++ b/Material.Blazor/Components/CircularProgress/MBCircularProgress.razor.cs
@@ -95,10 +95,10 @@ namespace Material.Blazor
         /// </summary>
         /// <param name="sender"></param>
         /// <param name="e"></param>
-        protected void OnValueSetCallback() => InvokeAsync(() => JsRuntime.InvokeVoidAsync("MaterialBlazor.MBCircularProgress.setProgress", ElementReference, Value));
+        protected void OnValueSetCallback() => InvokeAsync(() => InvokeJSVoidAsync("MaterialBlazor.MBCircularProgress.setProgress", ElementReference, Value));
 
 
         /// <inheritdoc/>
-        private protected override Task InstantiateMcwComponent() => JsRuntime.InvokeVoidAsync("MaterialBlazor.MBCircularProgress.init", ElementReference, Value);
+        private protected override Task InstantiateMcwComponent() => InvokeJSVoidAsync("MaterialBlazor.MBCircularProgress.init", ElementReference, Value);
     }
 }

--- a/Material.Blazor/Components/DataTable/MBDataTable.razor.cs
+++ b/Material.Blazor/Components/DataTable/MBDataTable.razor.cs
@@ -64,7 +64,7 @@ namespace Material.Blazor
 
                     if (HasProgressBar && HasInstantiated)
                     {
-                        InvokeAsync(() => JsRuntime.InvokeVoidAsync("MaterialBlazor.MBDataTable.setProgress", ElementReference, showProgress));
+                        InvokeAsync(() => InvokeJSVoidAsync("MaterialBlazor.MBDataTable.setProgress", ElementReference, showProgress));
                     }
                 }
             }
@@ -102,6 +102,6 @@ namespace Material.Blazor
 
 
         /// <inheritdoc/>
-        private protected override Task InstantiateMcwComponent() => JsRuntime.InvokeVoidAsync("MaterialBlazor.MBDataTable.init", ElementReference, HasProgressBar, ShowProgress);
+        private protected override Task InstantiateMcwComponent() => InvokeJSVoidAsync("MaterialBlazor.MBDataTable.init", ElementReference, HasProgressBar, ShowProgress);
     }
 }

--- a/Material.Blazor/Components/DatePicker/InternalDatePickerPanel.razor.cs
+++ b/Material.Blazor/Components/DatePicker/InternalDatePickerPanel.razor.cs
@@ -173,7 +173,7 @@ namespace Material.Blazor.Internal
         private async Task OnDayItemClickAsync(DateTime dateTime)
         {
             // Invoke JS first. if ComponentValue is set first we are at risk of this element being re-rendered before this line is run, making ListItemReference stale and causing a JS exception.
-            await JsRuntime.InvokeVoidAsync("MaterialBlazor.MBDatePicker.listItemClick", ListItemReference, Utilities.DateToString(dateTime, DateFormat));
+            await InvokeJSVoidAsync("MaterialBlazor.MBDatePicker.listItemClick", ListItemReference, Utilities.DateToString(dateTime, DateFormat));
             ComponentValue = dateTime;
             CachedComponentValue = Value;
             MonthsOffset = 0;
@@ -218,7 +218,7 @@ namespace Material.Blazor.Internal
             {
                 ScrollToYear = false;
 
-                await JsRuntime.InvokeVoidAsync("MaterialBlazor.MBDatePicker.scrollToYear", currentYearId);
+                await InvokeJSVoidAsync("MaterialBlazor.MBDatePicker.scrollToYear", currentYearId);
             }
         }
     }

--- a/Material.Blazor/Components/DatePicker/InternalDatePickerYearButton.razor.cs
+++ b/Material.Blazor/Components/DatePicker/InternalDatePickerYearButton.razor.cs
@@ -53,6 +53,7 @@ namespace Material.Blazor.Internal
         /// </summary>
         private string CurrentYearIdHelper => (DisplayYear == CurrentYear) ? CurrentYearId : null;
 
+
         private bool ButtonDisabled => (MaxDate < new DateTime(DisplayYear, 1, 1)) || (MinDate > new DateTime(DisplayYear, 12, 31));
 
 

--- a/Material.Blazor/Components/DatePicker/MBDatePicker.razor
+++ b/Material.Blazor/Components/DatePicker/MBDatePicker.razor
@@ -73,8 +73,8 @@
                                  DateFormat="@AppliedDateFormat"
                                  DateIsSelectable="@DateIsSelectable"
                                  DateSelectionCriteria="@DateSelectionCriteria"
-                                 MaxDate="@MaxDate"
-                                 MinDate="@MinDate"
+                                 MaxDate="@CascadingDefaults.AppliedDatePickerDefaultMaxDate(MaxDate)"
+                                 MinDate="@CascadingDefaults.AppliedDatePickerDefaultMinDate(MinDate)"
                                  @ref="Panel" />
     </div>
 </div>

--- a/Material.Blazor/Components/DatePicker/MBDatePicker.razor.cs
+++ b/Material.Blazor/Components/DatePicker/MBDatePicker.razor.cs
@@ -13,8 +13,8 @@ namespace Material.Blazor
     /// </summary>
     public partial class MBDatePicker : InputComponent<DateTime>
     {
-        private static readonly DateTime MinAllowableDate = DateTime.MinValue.AddMonths(1);
-        private static readonly DateTime MaxAllowableDate = DateTime.MaxValue.AddMonths(-1);
+        internal static readonly DateTime MinAllowableDate = DateTime.MinValue.AddMonths(1);
+        internal static readonly DateTime MaxAllowableDate = DateTime.MaxValue.AddMonths(-1);
 
         /// <summary>
         /// The select style.

--- a/Material.Blazor/Components/DatePicker/MBDatePicker.razor.cs
+++ b/Material.Blazor/Components/DatePicker/MBDatePicker.razor.cs
@@ -139,7 +139,7 @@ namespace Material.Blazor
         protected void OnValueSetCallback()
         {
             Panel.SetParameters(true, Value);
-            InvokeAsync(() => JsRuntime.InvokeVoidAsync("MaterialBlazor.MBDatePicker.listItemClick", Panel.ListItemReference, Utilities.DateToString(Value, AppliedDateFormat)).ConfigureAwait(false));
+            InvokeAsync(() => InvokeJSVoidAsync("MaterialBlazor.MBDatePicker.listItemClick", Panel.ListItemReference, Utilities.DateToString(Value, AppliedDateFormat)).ConfigureAwait(false));
         }
 
 
@@ -148,10 +148,10 @@ namespace Material.Blazor
         /// </summary>
         /// <param name="sender"></param>
         /// <param name="e"></param>
-        protected void OnDisabledSetCallback() => InvokeAsync(() => JsRuntime.InvokeVoidAsync("MaterialBlazor.MBDatePicker.setDisabled", ElementReference, AppliedDisabled));
+        protected void OnDisabledSetCallback() => InvokeAsync(() => InvokeJSVoidAsync("MaterialBlazor.MBDatePicker.setDisabled", ElementReference, AppliedDisabled));
 
 
         /// <inheritdoc/>
-        private protected override Task InstantiateMcwComponent() => JsRuntime.InvokeVoidAsync("MaterialBlazor.MBDatePicker.init", ElementReference);
+        private protected override Task InstantiateMcwComponent() => InvokeJSVoidAsync("MaterialBlazor.MBDatePicker.init", ElementReference);
     }
 }

--- a/Material.Blazor/Components/Dialog/MBDialog.razor.cs
+++ b/Material.Blazor/Components/Dialog/MBDialog.razor.cs
@@ -143,7 +143,7 @@ namespace Material.Blazor
         {
             try
             {
-                await JsRuntime.InvokeVoidAsync("MaterialBlazor.MBDialog.show", DialogElem, ObjectReference, EscapeKeyAction, ScrimClickAction);
+                await InvokeJSVoidAsync("MaterialBlazor.MBDialog.show", DialogElem, ObjectReference, EscapeKeyAction, ScrimClickAction);
             }
             catch
             {
@@ -158,7 +158,7 @@ namespace Material.Blazor
         /// </summary>
         public async Task HideAsync()
         {
-            await JsRuntime.InvokeVoidAsync("MaterialBlazor.MBDialog.hide", DialogElem);
+            await InvokeJSVoidAsync("MaterialBlazor.MBDialog.hide", DialogElem);
             IsOpen = false;
             await InvokeAsync(StateHasChanged);
         }

--- a/Material.Blazor/Components/Drawer/MBDrawer.razor.cs
+++ b/Material.Blazor/Components/Drawer/MBDrawer.razor.cs
@@ -68,7 +68,7 @@ namespace Material.Blazor
         public void Toggle(bool open)
         {
             isOpen = open;
-            InvokeAsync(() => JsRuntime.InvokeVoidAsync("MaterialBlazor.MBDrawer.toggle", DrawerElem, isOpen));
+            InvokeAsync(() => InvokeJSVoidAsync("MaterialBlazor.MBDrawer.toggle", DrawerElem, isOpen));
         }
 
 
@@ -86,6 +86,6 @@ namespace Material.Blazor
 
 
         /// <inheritdoc/>
-        private protected override Task InstantiateMcwComponent() => JsRuntime.InvokeVoidAsync("MaterialBlazor.MBDrawer.init", DrawerElem, isOpen);
+        private protected override Task InstantiateMcwComponent() => InvokeJSVoidAsync("MaterialBlazor.MBDrawer.init", DrawerElem, isOpen);
     }
 }

--- a/Material.Blazor/Components/FloatingActionButton/MBFloatingActionButton.razor.cs
+++ b/Material.Blazor/Components/FloatingActionButton/MBFloatingActionButton.razor.cs
@@ -74,7 +74,7 @@ namespace Material.Blazor
 
                     if (HasInstantiated)
                     {
-                        InvokeAsync(() => JsRuntime.InvokeVoidAsync("MaterialBlazor.MBFloatingActionButton.setExited", ElementReference, Exited));
+                        InvokeAsync(() => InvokeJSVoidAsync("MaterialBlazor.MBFloatingActionButton.setExited", ElementReference, Exited));
                     }
                 }
             }
@@ -98,6 +98,6 @@ namespace Material.Blazor
 
 
         /// <inheritdoc/>
-        private protected override Task InstantiateMcwComponent() => JsRuntime.InvokeVoidAsync("MaterialBlazor.MBFloatingActionButton.init", ElementReference, Exited);
+        private protected override Task InstantiateMcwComponent() => InvokeJSVoidAsync("MaterialBlazor.MBFloatingActionButton.init", ElementReference, Exited);
     }
 }

--- a/Material.Blazor/Components/Grid/MBGrid.cs
+++ b/Material.Blazor/Components/Grid/MBGrid.cs
@@ -550,7 +550,7 @@ namespace Material.Blazor
 #if Logging
             Log("GridSyncScroll()");
 #endif
-            await JsRuntime.InvokeVoidAsync("MaterialBlazor.MBGrid.syncScrollByID", GridHeaderID, GridBodyID);
+            await InvokeJSVoidAsync("MaterialBlazor.MBGrid.syncScrollByID", GridHeaderID, GridBodyID);
             //await JsRuntime.InvokeVoidAsync("MaterialBlazor.MBGrid.syncScrollByRef", GridHeaderRef, GridBodyRef);
         }
         #endregion
@@ -586,7 +586,7 @@ namespace Material.Blazor
             ColumnWidthArray = new float[ColumnConfigurations.Count()];
 
             // Measure the width of a vertical scrollbar (Used to set the padding of the header)
-            ScrollWidth = await JsRuntime.InvokeAsync<int>(
+            ScrollWidth = await BatchingJsRuntime.InvokeAsync<int>(
                 "MaterialBlazor.MBGrid.getScrollBarWidth",
                 "mb-grid-div-body");
             ScrollWidth = 0;
@@ -611,7 +611,7 @@ namespace Material.Blazor
                     colIndex++;
                 }
 
-                ColumnWidthArray = await JsRuntime.InvokeAsync<float[]>(
+                ColumnWidthArray = await BatchingJsRuntime.InvokeAsync<float[]>(
                         "MaterialBlazor.MBGrid.getTextWidths",
                         "mb-grid-header-td-measure",
                         ColumnWidthArray,
@@ -669,7 +669,7 @@ namespace Material.Blazor
                         colIndex++;
                     }
                 }
-                ColumnWidthArray = await JsRuntime.InvokeAsync<float[]>(
+                ColumnWidthArray = await BatchingJsRuntime.InvokeAsync<float[]>(
                         "MaterialBlazor.MBGrid.getTextWidths",
                         "mb-grid-body-td-measure",
                         ColumnWidthArray,

--- a/Material.Blazor/Components/IconButton/MBIconButton.razor.cs
+++ b/Material.Blazor/Components/IconButton/MBIconButton.razor.cs
@@ -55,6 +55,6 @@ namespace Material.Blazor
 
 
         /// <inheritdoc/>
-        private protected override Task InstantiateMcwComponent() => JsRuntime.InvokeVoidAsync("MaterialBlazor.MBIconButton.init", ElementReference);
+        private protected override Task InstantiateMcwComponent() => InvokeJSVoidAsync("MaterialBlazor.MBIconButton.init", ElementReference);
     }
 }

--- a/Material.Blazor/Components/IconButtonToggle/MBIconButtonToggle.razor.cs
+++ b/Material.Blazor/Components/IconButtonToggle/MBIconButtonToggle.razor.cs
@@ -78,7 +78,7 @@ namespace Material.Blazor
         /// </summary>
         /// <param name="sender"></param>
         /// <param name="e"></param>
-        protected void OnValueSetCallback() => InvokeAsync(() => JsRuntime.InvokeVoidAsync("MaterialBlazor.MBIconButtonToggle.setOn", ElementReference, Value));
+        protected void OnValueSetCallback() => InvokeAsync(() => InvokeJSVoidAsync("MaterialBlazor.MBIconButtonToggle.setOn", ElementReference, Value));
 
 
         /// <summary>
@@ -90,6 +90,6 @@ namespace Material.Blazor
 
 
         /// <inheritdoc/>
-        private protected override Task InstantiateMcwComponent() => JsRuntime.InvokeVoidAsync("MaterialBlazor.MBIconButtonToggle.init", ElementReference);
+        private protected override Task InstantiateMcwComponent() => InvokeJSVoidAsync("MaterialBlazor.MBIconButtonToggle.init", ElementReference);
     }
 }

--- a/Material.Blazor/Components/LinearProgress/MBLinearProgress.razor.cs
+++ b/Material.Blazor/Components/LinearProgress/MBLinearProgress.razor.cs
@@ -75,10 +75,10 @@ namespace Material.Blazor
         /// </summary>
         /// <param name="sender"></param>
         /// <param name="e"></param>
-        protected void OnValueSetCallback() => InvokeAsync(() => JsRuntime.InvokeVoidAsync("MaterialBlazor.MBLinearProgress.setProgress", ElementReference, Value, MyBufferValue));
+        protected void OnValueSetCallback() => InvokeAsync(() => InvokeJSVoidAsync("MaterialBlazor.MBLinearProgress.setProgress", ElementReference, Value, MyBufferValue));
 
 
         /// <inheritdoc/>
-        private protected override Task InstantiateMcwComponent() => JsRuntime.InvokeVoidAsync("MaterialBlazor.MBLinearProgress.init", ElementReference, Value, MyBufferValue);
+        private protected override Task InstantiateMcwComponent() => InvokeJSVoidAsync("MaterialBlazor.MBLinearProgress.init", ElementReference, Value, MyBufferValue);
     }
 }

--- a/Material.Blazor/Components/List/MBList.razor.cs
+++ b/Material.Blazor/Components/List/MBList.razor.cs
@@ -240,10 +240,10 @@ namespace Material.Blazor
         /// </summary>
         /// <param name="sender"></param>
         /// <param name="e"></param>
-        protected void OnDisabledSetCallback() => InvokeAsync(() => JsRuntime.InvokeVoidAsync("MaterialBlazor.MBList.init", ElementReference, KeyboardInteractions && !AppliedDisabled, Ripple));
+        protected void OnDisabledSetCallback() => InvokeAsync(() => InvokeJSVoidAsync("MaterialBlazor.MBList.init", ElementReference, KeyboardInteractions && !AppliedDisabled, Ripple));
 
 
         /// <inheritdoc/>
-        private protected override Task InstantiateMcwComponent() => JsRuntime.InvokeVoidAsync("MaterialBlazor.MBList.init", ElementReference, KeyboardInteractions && !AppliedDisabled, Ripple);
+        private protected override Task InstantiateMcwComponent() => InvokeJSVoidAsync("MaterialBlazor.MBList.init", ElementReference, KeyboardInteractions && !AppliedDisabled, Ripple);
     }
 }

--- a/Material.Blazor/Components/Menu/MBMenu.razor.cs
+++ b/Material.Blazor/Components/Menu/MBMenu.razor.cs
@@ -77,19 +77,19 @@ namespace Material.Blazor
         {
             if (IsOpen)
             {
-                await JsRuntime.InvokeVoidAsync("MaterialBlazor.MBMenu.hide", ElementReference);
+                await InvokeJSVoidAsync("MaterialBlazor.MBMenu.hide", ElementReference);
                 IsOpen = false;
             }
             else
             {
-                await JsRuntime.InvokeVoidAsync("MaterialBlazor.MBMenu.show", ElementReference);
+                await InvokeJSVoidAsync("MaterialBlazor.MBMenu.show", ElementReference);
                 IsOpen = true;
             }
         }
 
 
         /// <inheritdoc/>
-        private protected override Task InstantiateMcwComponent() => JsRuntime.InvokeVoidAsync("MaterialBlazor.MBMenu.init", ElementReference, ObjectReference);
+        private protected override Task InstantiateMcwComponent() => InvokeJSVoidAsync("MaterialBlazor.MBMenu.init", ElementReference, ObjectReference);
 
 
         /// <summary>

--- a/Material.Blazor/Components/MenuSurface/MBMenuSurface.razor.cs
+++ b/Material.Blazor/Components/MenuSurface/MBMenuSurface.razor.cs
@@ -76,19 +76,19 @@ namespace Material.Blazor
         {
             if (IsOpen)
             {
-                await JsRuntime.InvokeVoidAsync("MaterialBlazor.MBMenuSurface.hide", ElementReference);
+                await InvokeJSVoidAsync("MaterialBlazor.MBMenuSurface.hide", ElementReference);
                 IsOpen = false;
             }
             else
             {
-                await JsRuntime.InvokeVoidAsync("MaterialBlazor.MBMenuSurface.show", ElementReference);
+                await InvokeJSVoidAsync("MaterialBlazor.MBMenuSurface.show", ElementReference);
                 IsOpen = true;
             }
         }
 
 
         /// <inheritdoc/>
-        private protected override async Task InstantiateMcwComponent() => await JsRuntime.InvokeVoidAsync("MaterialBlazor.MBMenuSurface.init", ElementReference, ObjectReference);
+        private protected override async Task InstantiateMcwComponent() => await InvokeJSVoidAsync("MaterialBlazor.MBMenuSurface.init", ElementReference, ObjectReference);
 
 
         /// <summary>

--- a/Material.Blazor/Components/RadioButton/MBRadioButton.razor.cs
+++ b/Material.Blazor/Components/RadioButton/MBRadioButton.razor.cs
@@ -92,7 +92,7 @@ namespace Material.Blazor
         /// </summary>
         /// <param name="sender"></param>
         /// <param name="e"></param>
-        protected void OnValueSetCallback() => InvokeAsync(() => JsRuntime.InvokeVoidAsync("MaterialBlazor.MBRadioButton.setChecked", RadioButtonReference, Value.Equals(TargetCheckedValue)).ConfigureAwait(false));
+        protected void OnValueSetCallback() => InvokeAsync(() => InvokeJSVoidAsync("MaterialBlazor.MBRadioButton.setChecked", RadioButtonReference, Value.Equals(TargetCheckedValue)).ConfigureAwait(false));
 
 
         /// <summary>
@@ -100,7 +100,7 @@ namespace Material.Blazor
         /// </summary>
         /// <param name="sender"></param>
         /// <param name="e"></param>
-        protected void OnDisabledSetCallback() => InvokeAsync(() => JsRuntime.InvokeVoidAsync("MaterialBlazor.MBRadioButton.setDisabled", RadioButtonReference, AppliedDisabled));
+        protected void OnDisabledSetCallback() => InvokeAsync(() => InvokeJSVoidAsync("MaterialBlazor.MBRadioButton.setDisabled", RadioButtonReference, AppliedDisabled));
 
 
         private void OnInternalItemClick()
@@ -109,6 +109,6 @@ namespace Material.Blazor
         }
 
 
-        private protected override Task InstantiateMcwComponent() => JsRuntime.InvokeVoidAsync("MaterialBlazor.MBRadioButton.init", RadioButtonReference, FormReference, Value?.Equals(TargetCheckedValue) ?? false);
+        private protected override Task InstantiateMcwComponent() => InvokeJSVoidAsync("MaterialBlazor.MBRadioButton.init", RadioButtonReference, FormReference, Value?.Equals(TargetCheckedValue) ?? false);
     }
 }

--- a/Material.Blazor/Components/SegmentedButtonMulti/MBSegmentedButtonMulti.razor.cs
+++ b/Material.Blazor/Components/SegmentedButtonMulti/MBSegmentedButtonMulti.razor.cs
@@ -118,7 +118,7 @@ namespace Material.Blazor
         /// </summary>
         /// <param name="sender"></param>
         /// <param name="e"></param>
-        protected void OnValueSetCallback() => InvokeAsync(() => JsRuntime.InvokeVoidAsync("MaterialBlazor.MBSegmentedButtonMulti.setSelected", SegmentedButtonReference, Items.Select(x => Value.Contains(x.SelectedValue)).ToArray()));
+        protected void OnValueSetCallback() => InvokeAsync(() => InvokeJSVoidAsync("MaterialBlazor.MBSegmentedButtonMulti.setSelected", SegmentedButtonReference, Items.Select(x => Value.Contains(x.SelectedValue)).ToArray()));
 
 
         /// <summary>
@@ -126,11 +126,11 @@ namespace Material.Blazor
         /// </summary>
         /// <param name="sender"></param>
         /// <param name="e"></param>
-        protected void OnDisabledSetCallback() => InvokeAsync(() => JsRuntime.InvokeVoidAsync("MaterialBlazor.MBSegmentedButtonMulti.setDisabled", SegmentedButtonReference, AppliedDisabled));
+        protected void OnDisabledSetCallback() => InvokeAsync(() => InvokeJSVoidAsync("MaterialBlazor.MBSegmentedButtonMulti.setDisabled", SegmentedButtonReference, AppliedDisabled));
 
 
         /// <inheritdoc/>
-        private protected override Task InstantiateMcwComponent() => JsRuntime.InvokeVoidAsync("MaterialBlazor.MBSegmentedButtonMulti.init", SegmentedButtonReference, IsSingleSelect, ObjectReference);
+        private protected override Task InstantiateMcwComponent() => InvokeJSVoidAsync("MaterialBlazor.MBSegmentedButtonMulti.init", SegmentedButtonReference, IsSingleSelect, ObjectReference);
 
 
         /// <summary>

--- a/Material.Blazor/Components/Select/MBSelect.razor.cs
+++ b/Material.Blazor/Components/Select/MBSelect.razor.cs
@@ -182,7 +182,7 @@ namespace Material.Blazor
         /// </summary>
         /// <param name="sender"></param>
         /// <param name="e"></param>
-        protected void OnValueSetCallback() => InvokeAsync(() => JsRuntime.InvokeVoidAsync("MaterialBlazor.MBSelect.setIndex", SelectReference, Items.Select(x => x.SelectedValue).ToList().IndexOf(Value)));
+        protected void OnValueSetCallback() => InvokeAsync(() => InvokeJSVoidAsync("MaterialBlazor.MBSelect.setIndex", SelectReference, Items.Select(x => x.SelectedValue).ToList().IndexOf(Value)));
 
 
         /// <summary>
@@ -190,10 +190,10 @@ namespace Material.Blazor
         /// </summary>
         /// <param name="sender"></param>
         /// <param name="e"></param>
-        protected void OnDisabledSetCallback() => InvokeAsync(() => JsRuntime.InvokeVoidAsync("MaterialBlazor.MBSelect.setDisabled", SelectReference, AppliedDisabled));
+        protected void OnDisabledSetCallback() => InvokeAsync(() => InvokeJSVoidAsync("MaterialBlazor.MBSelect.setDisabled", SelectReference, AppliedDisabled));
 
 
         /// <inheritdoc/>
-        private protected override Task InstantiateMcwComponent() => JsRuntime.InvokeVoidAsync("MaterialBlazor.MBSelect.init", SelectReference, ObjectReference);
+        private protected override Task InstantiateMcwComponent() => InvokeJSVoidAsync("MaterialBlazor.MBSelect.init", SelectReference, ObjectReference);
     }
 }

--- a/Material.Blazor/Components/Slider/MBSlider.razor.cs
+++ b/Material.Blazor/Components/Slider/MBSlider.razor.cs
@@ -148,7 +148,7 @@ namespace Material.Blazor
         /// </summary>
         /// <param name="sender"></param>
         /// <param name="e"></param>
-        protected void OnValueSetCallback() => InvokeAsync(() => JsRuntime.InvokeVoidAsync("MaterialBlazor.MBSlider.setValue", ElementReference, Value));
+        protected void OnValueSetCallback() => InvokeAsync(() => InvokeJSVoidAsync("MaterialBlazor.MBSlider.setValue", ElementReference, Value));
 
 
         /// <summary>
@@ -156,10 +156,10 @@ namespace Material.Blazor
         /// </summary>
         /// <param name="sender"></param>
         /// <param name="e"></param>
-        protected void OnDisabledSetCallback() => InvokeAsync(() => JsRuntime.InvokeVoidAsync("MaterialBlazor.MBSlider.setDisabled", ElementReference, AppliedDisabled));
+        protected void OnDisabledSetCallback() => InvokeAsync(() => InvokeJSVoidAsync("MaterialBlazor.MBSlider.setDisabled", ElementReference, AppliedDisabled));
 
 
         /// <inheritdoc/>
-        private protected override Task InstantiateMcwComponent() => JsRuntime.InvokeVoidAsync("MaterialBlazor.MBSlider.init", ElementReference, ObjectReference, EventType, ContinuousInputDelay);
+        private protected override Task InstantiateMcwComponent() => InvokeJSVoidAsync("MaterialBlazor.MBSlider.init", ElementReference, ObjectReference, EventType, ContinuousInputDelay);
     }
 }

--- a/Material.Blazor/Components/Snackbar/InternalSnackbar.razor.cs
+++ b/Material.Blazor/Components/Snackbar/InternalSnackbar.razor.cs
@@ -55,6 +55,6 @@ namespace Material.Blazor.Internal
 
 
         /// <inheritdoc/>
-        private protected override Task InstantiateMcwComponent() => JsRuntime.InvokeVoidAsync("MaterialBlazor.MBSnackbar.init", SnackbarReference, ObjectReference, Snackbar.Settings.AppliedTimeout);
+        private protected override Task InstantiateMcwComponent() => InvokeJSVoidAsync("MaterialBlazor.MBSnackbar.init", SnackbarReference, ObjectReference, Snackbar.Settings.AppliedTimeout);
     }
 }

--- a/Material.Blazor/Components/Switch/MBSwitch.razor.cs
+++ b/Material.Blazor/Components/Switch/MBSwitch.razor.cs
@@ -46,7 +46,7 @@ namespace Material.Blazor
         /// </summary>
         /// <param name="sender"></param>
         /// <param name="e"></param>
-        protected void OnValueSetCallback() => InvokeAsync(() => JsRuntime.InvokeVoidAsync("MaterialBlazor.MBSwitch.setChecked", ElementReference, Value));
+        protected void OnValueSetCallback() => InvokeAsync(() => InvokeJSVoidAsync("MaterialBlazor.MBSwitch.setChecked", ElementReference, Value));
 
 
         /// <summary>
@@ -54,10 +54,10 @@ namespace Material.Blazor
         /// </summary>
         /// <param name="sender"></param>
         /// <param name="e"></param>
-        protected void OnDisabledSetCallback() => InvokeAsync(() => JsRuntime.InvokeVoidAsync("MaterialBlazor.MBSwitch.setDisabled", ElementReference, AppliedDisabled));
+        protected void OnDisabledSetCallback() => InvokeAsync(() => InvokeJSVoidAsync("MaterialBlazor.MBSwitch.setDisabled", ElementReference, AppliedDisabled));
 
 
         /// <inheritdoc/>
-        private protected override Task InstantiateMcwComponent() => JsRuntime.InvokeVoidAsync("MaterialBlazor.MBSwitch.init", ElementReference, ComponentValue);
+        private protected override Task InstantiateMcwComponent() => InvokeJSVoidAsync("MaterialBlazor.MBSwitch.init", ElementReference, ComponentValue);
     }
 }

--- a/Material.Blazor/Components/TabBar/MBTabBar.razor.cs
+++ b/Material.Blazor/Components/TabBar/MBTabBar.razor.cs
@@ -128,10 +128,10 @@ namespace Material.Blazor
         /// </summary>
         /// <param name="sender"></param>
         /// <param name="e"></param>
-        protected void OnValueSetCallback() => InvokeAsync(() => JsRuntime.InvokeVoidAsync("MaterialBlazor.MBTabBar.activateTab", ElementReference, Value));
+        protected void OnValueSetCallback() => InvokeAsync(() => InvokeJSVoidAsync("MaterialBlazor.MBTabBar.activateTab", ElementReference, Value));
 
 
         /// <inheritdoc/>
-        private protected override Task InstantiateMcwComponent() => JsRuntime.InvokeVoidAsync("MaterialBlazor.MBTabBar.init", ElementReference, ObjectReference);
+        private protected override Task InstantiateMcwComponent() => InvokeJSVoidAsync("MaterialBlazor.MBTabBar.init", ElementReference, ObjectReference);
     }
 }

--- a/Material.Blazor/Components/TextArea/MBTextArea.razor.cs
+++ b/Material.Blazor/Components/TextArea/MBTextArea.razor.cs
@@ -136,7 +136,7 @@ namespace Material.Blazor
         /// </summary>
         /// <param name="sender"></param>
         /// <param name="e"></param>
-        protected void OnValueSetCallback() => InvokeAsync(() => JsRuntime.InvokeVoidAsync("MaterialBlazor.MBTextField.setValue", ElementReference, Value));
+        protected void OnValueSetCallback() => InvokeAsync(() => InvokeJSVoidAsync("MaterialBlazor.MBTextField.setValue", ElementReference, Value));
 
 
         /// <summary>
@@ -144,11 +144,11 @@ namespace Material.Blazor
         /// </summary>
         /// <param name="sender"></param>
         /// <param name="e"></param>
-        protected void OnDisabledSetCallback() => InvokeAsync(() => JsRuntime.InvokeVoidAsync("MaterialBlazor.MBTextField.setDisabled", ElementReference, AppliedDisabled));
+        protected void OnDisabledSetCallback() => InvokeAsync(() => InvokeJSVoidAsync("MaterialBlazor.MBTextField.setDisabled", ElementReference, AppliedDisabled));
 
 
         /// <inheritdoc/>
-        private protected override Task InstantiateMcwComponent() => JsRuntime.InvokeVoidAsync("MaterialBlazor.MBTextField.init", ElementReference, HelperTextReference, HelperText.Trim(), HelperTextPersistent, PerformsValidation);
+        private protected override Task InstantiateMcwComponent() => InvokeJSVoidAsync("MaterialBlazor.MBTextField.init", ElementReference, HelperTextReference, HelperText.Trim(), HelperTextPersistent, PerformsValidation);
 
 
         private void OnValidationStateChangedCallback(object sender, EventArgs e)
@@ -158,7 +158,7 @@ namespace Material.Blazor
                 var fieldIdentifier = FieldIdentifier.Create(ValidationMessageFor);
                 var validationMessage = string.Join("<br />", EditContext.GetValidationMessages(fieldIdentifier));
 
-                InvokeAsync(() => JsRuntime.InvokeVoidAsync("MaterialBlazor.MBTextField.setHelperText", ElementReference, HelperTextReference, HelperText.Trim(), HelperTextPersistent, PerformsValidation, !string.IsNullOrEmpty(Value), validationMessage));
+                InvokeAsync(() => InvokeJSVoidAsync("MaterialBlazor.MBTextField.setHelperText", ElementReference, HelperTextReference, HelperText.Trim(), HelperTextPersistent, PerformsValidation, !string.IsNullOrEmpty(Value), validationMessage));
             }
         }
     }

--- a/Material.Blazor/Components/TextField/MBTextField.razor.cs
+++ b/Material.Blazor/Components/TextField/MBTextField.razor.cs
@@ -199,7 +199,7 @@ namespace Material.Blazor
         /// </summary>
         /// <param name="sender"></param>
         /// <param name="e"></param>
-        protected void OnValueSetCallback() => InvokeAsync(() => JsRuntime.InvokeVoidAsync("MaterialBlazor.MBTextField.setValue", ElementReference, Value));
+        protected void OnValueSetCallback() => InvokeAsync(() => InvokeJSVoidAsync("MaterialBlazor.MBTextField.setValue", ElementReference, Value));
 
 
         /// <summary>
@@ -207,18 +207,18 @@ namespace Material.Blazor
         /// </summary>
         /// <param name="sender"></param>
         /// <param name="e"></param>
-        protected void OnDisabledSetCallback() => InvokeAsync(() => JsRuntime.InvokeVoidAsync("MaterialBlazor.MBTextField.setDisabled", ElementReference, AppliedDisabled));
+        protected void OnDisabledSetCallback() => InvokeAsync(() => InvokeJSVoidAsync("MaterialBlazor.MBTextField.setDisabled", ElementReference, AppliedDisabled));
 
 
         /// <inheritdoc/>
-        private protected override Task InstantiateMcwComponent() => JsRuntime.InvokeVoidAsync("MaterialBlazor.MBTextField.init", ElementReference, HelperTextReference, HelperText.Trim(), HelperTextPersistent, PerformsValidation);
+        private protected override Task InstantiateMcwComponent() => InvokeJSVoidAsync("MaterialBlazor.MBTextField.init", ElementReference, HelperTextReference, HelperText.Trim(), HelperTextPersistent, PerformsValidation);
 
 
         /// <summary>
         /// Selects the text field - used by <see cref="MBNumericDoubleField"/>.
         /// </summary>
         /// <returns></returns>
-        internal Task SetType(string value, string type, bool formNoValidate) => JsRuntime.InvokeVoidAsync("MaterialBlazor.MBTextField.setType", ElementReference, value, InputReference, type, formNoValidate);
+        internal Task SetType(string value, string type, bool formNoValidate) => InvokeJSVoidAsync("MaterialBlazor.MBTextField.setType", ElementReference, value, InputReference, type, formNoValidate);
 
 
         private void OnValidationStateChangedCallback(object sender, EventArgs e)
@@ -228,7 +228,7 @@ namespace Material.Blazor
                 var fieldIdentifier = FieldIdentifier.Create(ValidationMessageFor);
                 var validationMessage = string.Join("<br />", EditContext.GetValidationMessages(fieldIdentifier));
 
-                InvokeAsync(() => JsRuntime.InvokeVoidAsync("MaterialBlazor.MBTextField.setHelperText", ElementReference, HelperTextReference, HelperText.Trim(), HelperTextPersistent, PerformsValidation, !string.IsNullOrEmpty(Value), validationMessage));
+                InvokeAsync(() => InvokeJSVoidAsync("MaterialBlazor.MBTextField.setHelperText", ElementReference, HelperTextReference, HelperText.Trim(), HelperTextPersistent, PerformsValidation, !string.IsNullOrEmpty(Value), validationMessage));
             }
         }
     }

--- a/Material.Blazor/Components/Tooltip/InternalTooltipAnchor.razor.cs
+++ b/Material.Blazor/Components/Tooltip/InternalTooltipAnchor.razor.cs
@@ -91,7 +91,7 @@ namespace Material.Blazor.Internal
 
             if (refs.Length > 0)
             {
-                await JsRuntime.InvokeVoidAsync("MaterialBlazor.MBTooltip.init", refs.Select(r => r.ElementReference));
+                await InvokeJSVoidAsync("MaterialBlazor.MBTooltip.init", refs.Select(r => r.ElementReference));
 
                 foreach (var item in refs)
                 {

--- a/Material.Blazor/Components/TopAppBar/MBTopAppBar.razor.cs
+++ b/Material.Blazor/Components/TopAppBar/MBTopAppBar.razor.cs
@@ -69,6 +69,6 @@ namespace Material.Blazor
 
 
         /// <inheritdoc/>
-        private protected override Task InstantiateMcwComponent() => JsRuntime.InvokeVoidAsync("MaterialBlazor.MBTopAppBar.init", HeaderElem, ScrollTarget);
+        private protected override Task InstantiateMcwComponent() => InvokeJSVoidAsync("MaterialBlazor.MBTopAppBar.init", HeaderElem, ScrollTarget);
     }
 }

--- a/Material.Blazor/Foundation/BatchingJsRuntime.cs
+++ b/Material.Blazor/Foundation/BatchingJsRuntime.cs
@@ -56,6 +56,9 @@ namespace Material.Blazor.Internal
             var call = new Call(identifier, args);
             queuedCalls.TryAdd(batchingWrapper.CrossReferenceId, new());
             queuedCalls[batchingWrapper.CrossReferenceId].Enqueue(call);
+
+            batchingWrapper.InvokeStateHasChanged();
+
             return call.Task;
         }
 

--- a/Material.Blazor/Foundation/ComponentFoundation.cs
+++ b/Material.Blazor/Foundation/ComponentFoundation.cs
@@ -92,7 +92,7 @@ namespace Material.Blazor.Internal
         /// <summary>
         /// A markup capable tooltip.
         /// </summary>
-        [Parameter] public string Tooltip { get; set; }
+        [Parameter] public string Tooltip { get; set; } = "";
 
 
         /// <summary>

--- a/Material.Blazor/Foundation/DialogAwareBatchingJSRuntime.cs
+++ b/Material.Blazor/Foundation/DialogAwareBatchingJSRuntime.cs
@@ -6,21 +6,35 @@ namespace Material.Blazor.Internal
     {
         private readonly IBatchingJSRuntime underlyingJSRuntime;
         private readonly MBDialog dialog;
+
+
         public DialogAwareBatchingJSRuntime(IBatchingJSRuntime underlyingJSRuntime, MBDialog dialog)
         {
             this.underlyingJSRuntime = underlyingJSRuntime;
             this.dialog = dialog;
         }
+
+
+        /// <inheritdoc/>
         public async Task<T> InvokeAsync<T>(string identifier, params object[] args)
         {
             await dialog.Opened;
             return await underlyingJSRuntime.InvokeAsync<T>(identifier, args);
         }
 
-        public async Task InvokeVoidAsync(string identifier, params object[] args)
+
+        /// <inheritdoc/>
+        public async Task InvokeVoidAsync(MBBatchingWrapper batchingWrapper, string identifier, params object[] args)
         {
             await dialog.Opened;
-            await underlyingJSRuntime.InvokeVoidAsync(identifier, args);
+            await underlyingJSRuntime.InvokeVoidAsync(batchingWrapper, identifier, args);
+        }
+
+
+        /// <inheritdoc/>
+        public Task FlushBatch(MBBatchingWrapper batchingWrapper)
+        {
+            return underlyingJSRuntime.FlushBatch(batchingWrapper);
         }
     }
 }

--- a/Material.Blazor/Foundation/IBatchingJsRuntime.cs
+++ b/Material.Blazor/Foundation/IBatchingJsRuntime.cs
@@ -11,10 +11,11 @@ namespace Material.Blazor.Internal
         /// <summary>
         /// Same as <see cref="JSRuntimeExtensions.InvokeVoidAsync(IJSRuntime, string, object[])"/>, except calls are batched in 10ms intervals.
         /// </summary>
+        /// <param name="batchingWrapper"></param>
         /// <param name="identifier"></param>
         /// <param name="args"></param>
         /// <returns></returns>
-        Task InvokeVoidAsync(string identifier, params object[] args);
+        Task InvokeVoidAsync(MBBatchingWrapper batchingWrapper, string identifier, params object[] args);
 
 
         /// <summary>
@@ -25,5 +26,13 @@ namespace Material.Blazor.Internal
         /// <param name="args"></param>
         /// <returns></returns>        
         Task<T> InvokeAsync<T>(string identifier, params object[] args);
+
+
+        /// <summary>
+        /// Flushes the batch associated with the supplied batching wrapper.
+        /// </summary>
+        /// <param name="batchingWrapper"></param>
+        /// <returns></returns>
+        Task FlushBatch(MBBatchingWrapper batchingWrapper);
     }
 }

--- a/Material.Blazor/Model/MBCascadingDefaults.cs
+++ b/Material.Blazor/Model/MBCascadingDefaults.cs
@@ -1,3 +1,4 @@
+using System;
 using System.Collections.Generic;
 using System.Linq;
 
@@ -331,6 +332,36 @@ namespace Material.Blazor
         /// <param name="criteria">The criteria style parameter passed to the <see cref="MBDatePicker"/></param>
         /// <returns>The <see cref="MBDateSelectionCriteria"/> to apply.</returns>
         internal MBDateSelectionCriteria AppliedDateSelectionCriteria(MBDateSelectionCriteria? criteria = null) => criteria ?? DateSelectionCriteria;
+
+
+
+        private DateTime datePickerDefaultMinDate = MBDatePicker.MinAllowableDate;
+        /// <summary>
+        /// The default minimum date <see cref="MBDatePicker"/>.
+        /// </summary>
+        public DateTime DatePickerDefaultMinDate { get => datePickerDefaultMinDate; set => SetParameter(ref datePickerDefaultMinDate, value); }
+
+        /// <summary>
+        /// The minimum date to apply to a <see cref="MBDatePicker"/>.
+        /// </summary>
+        /// <param name="criteria">The criteria style parameter passed to the <see cref="MBDatePicker"/></param>
+        /// <returns>The <see cref="MBDateSelectionCriteria"/> to apply.</returns>
+        internal DateTime AppliedDatePickerDefaultMinDate(DateTime minDate) => minDate == default || minDate <= MBDatePicker.MinAllowableDate ? DatePickerDefaultMinDate : minDate;
+
+
+
+        private DateTime datePickerDefaultMaxDate = MBDatePicker.MaxAllowableDate;
+        /// <summary>
+        /// The default maximum date <see cref="MBDatePicker"/>.
+        /// </summary>
+        public DateTime DatePickerDefaultMaxDate { get => datePickerDefaultMaxDate; set => SetParameter(ref datePickerDefaultMaxDate, value); }
+
+        /// <summary>
+        /// The maximum date to apply to a <see cref="MBDatePicker"/>.
+        /// </summary>
+        /// <param name="criteria">The criteria style parameter passed to the <see cref="MBDatePicker"/></param>
+        /// <returns>The <see cref="MBDateSelectionCriteria"/> to apply.</returns>
+        internal DateTime AppliedDatePickerDefaultMaxDate(DateTime maxDate) => maxDate == default || maxDate >= MBDatePicker.MaxAllowableDate ? DatePickerDefaultMaxDate : maxDate;
 
 
 


### PR DESCRIPTION
Removes race condition arising from Batching JS's prior implementation with timers, where Blazor might dispose of components before their JS instantiation call had run.