### PR TITLE
Fix incremental build of Material.Blazor project

### DIFF
--- a/Material.Blazor/Material.Blazor.csproj
+++ b/Material.Blazor/Material.Blazor.csproj
@@ -25,10 +25,6 @@
 		<EnforceCodeStyleInBuild>true</EnforceCodeStyleInBuild>
 	</PropertyGroup>
 
-	<PropertyGroup>
-		<DisableFastUpToDateCheck>true</DisableFastUpToDateCheck>
-	</PropertyGroup>
-	
 	<ItemGroup>
 		<None Include="..\README.md" Pack="true" PackagePath="\" />
 	</ItemGroup>
@@ -45,6 +41,7 @@
 		<Content Remove="package-lock.json" />
 		<Content Remove="package.json" />
 		<Content Remove="tsconfig.json" />
+		<Content Remove="wwwroot\intermediate.js" />
 	</ItemGroup>
 
 	<ItemGroup>
@@ -164,6 +161,14 @@
 			</Code>
 		</Task>
 	</UsingTask>
+
+	<ItemGroup>
+		<UpToDateCheckInput Include="@(InputStaticAssetsScripts)" Set="Scripts" />
+		<UpToDateCheckOutput Include="@(OutputStaticAssetsScripts)" Set="Scripts" />
+		<UpToDateCheckInput Include="@(InputStaticAssetsStyles)" Set="Styles" />
+		<UpToDateCheckOutput Include="@(OutputStaticAssetsStyles)" Set="Styles" />
+	</ItemGroup>
+
 	<Target Name="BuildScripts" Inputs="@(InputStaticAssetsScripts)" Outputs="@(OutputStaticAssetsScripts)" BeforeTargets="PreBuildEvent" AfterTargets="CheckIfNpmExists" Condition=" '$(NpmReturnCode)' == '0' ">
 		<Message Importance="high" Text="***** MakeDir wwwroot (M.B Scripts)" />
 		<MakeDir Directories="wwwroot" />


### PR DESCRIPTION
It should not be necessary to disable Visual Studio's fast up-to-date check. Instead, we just need to configure it correctly when working with additional files during build.

In this case, we add `UpToDateCheckInput` and `UpToDateCheckOutput` for all scripts and styles. Because each of these are compiled individually (that is, changes to scripts don't effect styles, etc) we model them with `Set` metadata that enforces partitioning between these groups of inputs/outputs.

Another change is to remove the `wwwroot\intermediate.js` file from the project. This file is created during build, and deleted as the build completes. If it is not removed, then VS watches for file system activity on this file and considers it's creation and deletion as an indication that the project has changed in some way that requires a further build. It's idiomatic in .NET to generate such temporary files in the intermediate (`obj`) folder, though that pattern is not common in the web world, so on balance it's easier to have the project ignore the file.

With these changes, builds in VS are much faster when no C# code is changed, as the DLL is not regenerated. If no C#/TS/SCSS files have changed, the build completes in milliseconds.

I hope this makes you more productive!

---

While testing this I noticed a potential issue which I've logged as https://github.com/dotnet/project-system/issues/7803. That issue should not stop you merging this, as it relates to _overbuild_ (not _underbuild_ which would be a real problem). By disabling the fast up-to-date check you are essentially getting overbuild all the time, so this PR will still improve productivity in most cases. I hope to fix that issue soon, which would then provide reliable incremental builds for your project.